### PR TITLE
WIP: Nested Configurations + Advanced Types

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,17 @@ Supports Python 3.6+
 pip install spock-config
 ```
 
+## What's New
+
+See [Releases](https://github.com/fidelity/spock/releases) for more information.
+
+#### November 25th, 2020
+
+* Addition of [Advanced Types](advanced_features/Advanced-Types.md)
+* Bumped support to include Python 3.9
+* Checks for circular dependencies in composed config files
+* Pickle support for dynamically created `spock` class
+
 ## Documentation
 
 Current documentation and more information can be found [here](https://fidelity.github.io/spock/).
@@ -38,7 +49,7 @@ and automatic defaults.
 set of parameters.
 * Multiple Configuration File Types: Configurations are specified from YAML, TOML, or JSON files.
 * Hierarchical Configuration: Composed from multiple configuration files via simple include statements.
-* Command-Line Overrides: Quickly experiment by overriding a value with automatically generated command line arguments
+* Command-Line Overrides: Quickly experiment by overriding a value with automatically generated command line arguments.
 * Immutable: All classes are *frozen* preventing any misuse or accidental overwrites.
 * Tractability and Reproducibility: Save currently running parameter configuration with a single chained command. 
 

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -3,7 +3,7 @@
 ### Requirements
 
 * Python: 3.6+
-* Dependencies: attr, GitPython, PyYAML, toml
+* Dependencies: attrs, GitPython, PyYAML, toml
 * Tested OS: Unix (Ubuntu 16.04, Ubuntu 18.04), OSX (10.14.6)
 
 ### Install/Upgrade

--- a/docs/advanced_features/Advanced-Types.md
+++ b/docs/advanced_features/Advanced-Types.md
@@ -1,0 +1,96 @@
+# Advanced Types
+
+`spock` also supports nested `List` or `Tuple` types and advanced argument types (such as repeated objects) that 
+use `Enum` or `@spock` decorated classes. All of the advanced types support the use of `Optional` and setting default 
+values. Example usage of advanced types can be found in the unittests 
+[here](https://github.com/fidelity/spock/tree/master/tests).
+
+### Nested List/Tuple Types
+
+`List[List[int]]` -- Defines a list of list of integers.
+
+`List[List[str]]` -- Defines a list of list of strings.
+
+### Lists/Tuples of `Enum`
+
+```python
+from enum import Enum
+from spock.config import spock
+from typing import List
+
+
+class StrChoice(Enum):
+    option_1 = 'option_1'
+    option_2 = 'option_2'
+
+@spock
+class TypeConfig:
+    list_choice_p_str: List[StrChoice] # YAML -- list_choice_p_str: ['option_1', 'option_2']
+```
+
+### List/Tuple of Repeated `@spock` Classes 
+
+These can be accessed by index and are iterable.
+
+```python
+from spock.config import spock
+from typing import List
+
+
+@spock
+class NestedListStuff:
+    one: int
+    two: str
+
+@spock
+class TypeConfig:
+    nested_list: List[NestedListStuff] # To Set Default Value append '= NestedListStuff'
+```
+
+With YAML definitions:
+
+```yaml
+# Nested List configuration
+nested_list: NestedListStuff
+NestedListStuff:
+    - one: 10
+      two: hello
+    - one: 20
+      two: bye
+```
+
+### `Enum` of `@spock` Classes
+
+```python
+from enum import Enum
+from spock.config import spock
+
+
+@spock
+class NestedStuff:
+    one: int
+    two: str
+
+
+@spock
+class NestedListStuff:
+    one: int
+    two: str
+
+
+class ClassChoice(Enum):
+    class_nested_stuff = NestedStuff
+    class_nested_list_stuff = NestedListStuff
+```
+
+With YAML definitions:
+
+```yaml
+# Nested List configuration
+nested_list: NestedListStuff
+NestedListStuff:
+    - one: 10
+      two: hello
+    - one: 20
+      two: bye
+```

--- a/docs/basic_tutorial/Define.md
+++ b/docs/basic_tutorial/Define.md
@@ -9,7 +9,8 @@ All examples can be found [here](https://github.com/fidelity/spock/blob/master/e
 
 ### Supported Parameter Types
 
-`spock` supports the following argument types (note `List`, `Tuple`, and `Optional` are defined in the `typing` 
+#### Basic Types
+`spock` supports the following basic argument types (note `List`, `Tuple`, and `Optional` are defined in the `typing` 
 standard library while `Enum` is within the `enum` standard library):
 
 | Python Base or Typing Type (Required) | Optional Type | Description |
@@ -22,12 +23,12 @@ standard library while `Enum` is within the `enum` standard library):
 | Tuple[type] | Optional[Tuple[type]] | Basic tuple type parameter of base types such as int, float, etc. (e.g. (10, 2)) |
 | Enum | Optional[Enum] | Parameter that must be from a defined set of values of base types such as int, float, etc. |
 
-Parameters that are specified without the `Optional[]` type will be considered REQUIRED and therefore will raise an
+Parameters that are specified without the `Optional[]` type will be considered **REQUIRED** and therefore will raise an
 Exception if not value is specified. 
 
-Nested types are also supported. For instance:
-
-`List[List[int]]` which would define a list of list of integers!
+#### Advanced Types
+`spock` supports more than just basic types. More information can be found in 
+the [Advanced Types](advanced_features/Advanced-Types.md) section.
 
 ### Defining A spock Class
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,8 @@ Motivation = "docs/Motivation.md"
     [[tool.portray.mkdocs.nav."Advanced Features"]]
     "Inheritance" = "docs/advanced_features/Inheritance.md"
     [[tool.portray.mkdocs.nav."Advanced Features"]]
+    "Advanced Types" = "docs/advanced_features/Advanced-Types.md"
+    [[tool.portray.mkdocs.nav."Advanced Features"]]
     "Local Defintions" = "docs/advanced_features/Local-Definitions.md"
     [[tool.portray.mkdocs.nav."Advanced Features"]]
     "Keyword Configs" = "docs/advanced_features/Keyword-Configs.md"

--- a/spock/backend/attr/builder.py
+++ b/spock/backend/attr/builder.py
@@ -111,13 +111,14 @@ class AttrBuilder(BaseBuilder):
             if len(match_idx) > 1:
                 raise ValueError('Match error -- multiple classes with the same name definition')
             else:
+                if args.get(self.input_classes[match_idx[0]].__name__) is None:
+                    raise ValueError(f'Missing config file definition for the referenced class '
+                                     f'{self.input_classes[match_idx[0]].__name__}')
                 current_arg = args.get(self.input_classes[match_idx[0]].__name__)
                 if isinstance(current_arg, list):
                     class_value = [self.input_classes[match_idx[0]](**val) for val in current_arg]
                 else:
-                    class_value = self.input_classes[match_idx[0]](
-                        **args.get(self.input_classes[match_idx[0]].__name__)
-                    )
+                    class_value = self.input_classes[match_idx[0]](**current_arg)
             return_value = class_value
         # else return the expected value
         else:

--- a/spock/backend/attr/builder.py
+++ b/spock/backend/attr/builder.py
@@ -51,18 +51,75 @@ class AttrBuilder(BaseBuilder):
 
     def _handle_arguments(self, args, class_obj):
         attr_name = class_obj.__name__
-        fields = {}
-        for val in class_obj.__attrs_attrs__:
-            # Check if namespace is named and then check for key -- checking for local class def
-            if attr_name in args and val.name in args[attr_name]:
-                fields[val.name] = args[attr_name][val.name]
-            # If not named then just check for keys -- checking for global def
-            elif val.name in args:
-                fields[val.name] = args[val.name]
-            # Check for special keys to set
-            if 'special_key' in val.metadata and val.metadata['special_key'] is not None:
-                if val.name in args:
-                    self.save_path = args[val.name]
-                elif val.default is not None:
-                    self.save_path = val.default
+        class_names = [val.__name__ for val in self.input_classes]
+        # Handle repeated classes
+        if attr_name in class_names and attr_name in args and isinstance(args[attr_name], list):
+            fields = self._handle_repeated(args[attr_name], attr_name, class_names)
+        # Handle non-repeated classes
+        else:
+            fields = {}
+            for val in class_obj.__attrs_attrs__:
+                # Check if namespace is named and then check for key -- checking for local class def
+                if attr_name in args and val.name in args[attr_name]:
+                    fields[val.name] = self._handle_nested_class(args, args[attr_name][val.name], class_names)
+                # If not named then just check for keys -- checking for global def
+                elif val.name in args:
+                    fields[val.name] = self._handle_nested_class(args, args[val.name], class_names)
+                # Check for special keys to set
+                if 'special_key' in val.metadata and val.metadata['special_key'] is not None:
+                    if val.name in args:
+                        self.save_path = args[val.name]
+                    elif val.default is not None:
+                        self.save_path = val.default
         return fields
+
+    def _handle_repeated(self, args, check_value, class_names):
+        """Handles repeated classes as lists
+
+        *Args*:
+
+            args: dictionary of arguments from the configs
+            check_value: value to check classes against
+            class_names: current class names
+
+        *Returns*:
+
+            list of input_class[match)idx[0]] types filled with repeated values
+
+        """
+        # Check to see if the value trying to be set is actually an input class
+        match_idx = [idx for idx, val in enumerate(class_names) if val == check_value]
+        return [self.input_classes[match_idx[0]](**val) for val in args]
+
+    def _handle_nested_class(self, args, check_value, class_names):
+        """Handles passing another class to the field dictionary
+
+        *Args*:
+            args: dictionary of arguments from the configs
+            check_value: value to check classes against
+            class_names: current class names
+
+        *Returns*:
+
+            either the check_value or the necessary class
+
+        """
+        # Check to see if the value trying to be set is actually an input class
+        match_idx = [idx for idx, val in enumerate(class_names) if val == check_value]
+        # If so then create the needed class object by unrolling the args to **kwargs and return it
+        if len(match_idx) > 0:
+            if len(match_idx) > 1:
+                raise ValueError('Match error -- multiple classes with the same name definition')
+            else:
+                current_arg = args.get(self.input_classes[match_idx[0]].__name__)
+                if isinstance(current_arg, list):
+                    class_value = [self.input_classes[match_idx[0]](**val) for val in current_arg]
+                else:
+                    class_value = self.input_classes[match_idx[0]](
+                        **args.get(self.input_classes[match_idx[0]].__name__)
+                    )
+            return_value = class_value
+        # else return the expected value
+        else:
+            return_value = check_value
+        return return_value

--- a/spock/backend/attr/config.py
+++ b/spock/backend/attr/config.py
@@ -5,9 +5,9 @@
 
 """Creates the spock config interface that wraps attr"""
 
+import sys
 import attr
 from spock.backend.attr.typed import katra
-import sys
 
 
 def spock_attr(cls):

--- a/spock/backend/attr/saver.py
+++ b/spock/backend/attr/saver.py
@@ -33,7 +33,11 @@ class AttrSaver(BaseSaver):
             if file_extension == '.json':
                 out_dict.update({key: attr.asdict(val)})
             else:
-                out_dict.update({('# ' + key): attr.asdict(val)})
+                if isinstance(val, list):
+                    val = [attr.asdict(inner_val) for inner_val in val]
+                    out_dict.update({('# ' + key): val})
+                else:
+                    out_dict.update({('# ' + key): attr.asdict(val)})
         # Convert values
         clean_dict = self._clean_output(out_dict, extra_info)
         return clean_dict

--- a/spock/backend/attr/saver.py
+++ b/spock/backend/attr/saver.py
@@ -29,9 +29,14 @@ class AttrSaver(BaseSaver):
     def _clean_up_values(self, payload, extra_info, file_extension):
         out_dict = {}
         for key, val in vars(payload).items():
-            # Append comment tag to the base class and convert the spock class to a dict
+            # Skip comment append in JSON as it doesn't allow comments
             if file_extension == '.json':
-                out_dict.update({key: attr.asdict(val)})
+                if isinstance(val, list):
+                    val = [attr.asdict(inner_val) for inner_val in val]
+                    out_dict.update({(key): val})
+                else:
+                    out_dict.update({key: attr.asdict(val)})
+            # Append comment tag to the base class and convert the spock class to a dict
             else:
                 if isinstance(val, list):
                     val = [attr.asdict(inner_val) for inner_val in val]

--- a/spock/backend/attr/typed.py
+++ b/spock/backend/attr/typed.py
@@ -7,6 +7,7 @@
 
 import sys
 from enum import EnumMeta
+from functools import partial
 from typing import TypeVar
 from typing import Union
 import attr
@@ -168,6 +169,34 @@ def _enum_katra(typed, default=None, optional=False):
     """
     # First check if the types of Enum are the same
     base_type, allowed = _check_enum_props(typed)
+    if base_type.__name__ == 'type':
+        x = _enum_class_katra(typed=typed, allowed=allowed, default=default, optional=optional)
+    else:
+        x = _enum_base_katra(typed=typed, base_type=base_type, allowed=allowed, default=default, optional=optional)
+    return x
+
+
+def _enum_base_katra(typed, base_type, allowed, default=None, optional=False):
+    """Private interface to create a base Enum typed katra
+
+    Here we handle the base types of enums that allows us to force a type check on the instance
+
+    A 'katra' is the basic functional unit of `spock`. It defines a parameter using attrs as the backend, type checks
+    both simple types and subscripted GenericAlias types (e.g. lists and tuples), handles setting default parameters,
+    and deals with parameter optionality
+
+    *Args*:
+        typed: the type of the parameter to define
+        base_type: underlying base type
+        allowed: set of allowed values
+        default: the default value to assign if given
+        optional: whether to make the parameter optional or not (thus allowing None)
+
+    *Returns*:
+
+        x: Attribute from attrs
+
+    """
     if default is not None:
         x = attr.ib(
             validator=[attr.validators.instance_of(base_type), attr.validators.in_(allowed)],
@@ -179,6 +208,61 @@ def _enum_katra(typed, default=None, optional=False):
     else:
         x = attr.ib(validator=[attr.validators.instance_of(base_type), attr.validators.in_(allowed)], type=typed,
                     metadata={'base': typed.__name__})
+    return x
+
+
+def _in_type(instance, attribute, value, options):
+    """attrs validator for class type enum
+
+    Checks if the type of the class (e.g. value) is in the specified set of types provided
+
+    *Args*:
+
+        instance: current object instance
+        attribute: current attribute instance
+        value: current value trying to be set in the attrs instance
+        options: list, tuple, or enum of allowed options
+
+    *Returns*:
+
+    """
+    if type(options) not in [list, tuple, EnumMeta]:
+        raise TypeError(f'options argument must be of type List, Tuple, or Enum -- given {type(options)}')
+    if type(value) not in options:
+        raise ValueError(f'{attribute.name} must be in {options}')
+
+
+def _enum_class_katra(typed, allowed, default=None, optional=False):
+    """Private interface to create a base Enum typed katra
+
+    Here we handle the class based types of enums. Seeing as these classes are generated dynamically we cannot
+    force type checking of a specific instance however the in_ validator will catch an incorrect instance type
+
+    A 'katra' is the basic functional unit of `spock`. It defines a parameter using attrs as the backend, type checks
+    both simple types and subscripted GenericAlias types (e.g. lists and tuples), handles setting default parameters,
+    and deals with parameter optionality
+
+    *Args*:
+
+        typed: the type of the parameter to define
+        allowed: set of allowed values
+        default: the default value to assign if given
+        optional: whether to make the parameter optional or not (thus allowing None)
+
+    *Returns*:
+
+        x: Attribute from attrs
+
+    """
+    if default is not None:
+        x = attr.ib(
+            validator=[partial(_in_type, options=allowed)], default=default, metadata={'base': typed.__name__})
+    elif optional:
+        x = attr.ib(
+            validator=attr.validators.optional([partial(_in_type, options=allowed)]),
+            default=default, metadata={'base': typed.__name__})
+    else:
+        x = attr.ib(validator=[partial(_in_type, options=allowed)], metadata={'base': typed.__name__})
     return x
 
 

--- a/spock/backend/base.py
+++ b/spock/backend/base.py
@@ -12,11 +12,26 @@ import os
 from pathlib import Path
 import sys
 from uuid import uuid1
+import yaml
 from spock.handlers import JSONHandler
 from spock.handlers import TOMLHandler
 from spock.handlers import YAMLHandler
 from spock.utils import add_info
+from spock.utils import convert_save_dict
 from spock.utils import make_argument
+
+
+class Spockspace(argparse.Namespace):
+    """Inherits from Namespace to implement a pretty print on the obj
+
+    Overwrites the __repr__ method with a pretty version of printing
+
+    """
+    def __init__(self, **kwargs):
+        super(Spockspace, self).__init__(**kwargs)
+
+    def __repr__(self):
+        return yaml.dump(self.__dict__, default_flow_style=False)
 
 
 class BaseSaver(ABC):  # pylint: disable=too-few-public-methods
@@ -103,16 +118,29 @@ class BaseSaver(ABC):  # pylint: disable=too-few-public-methods
         clean_dict = {}
         for key, val in out_dict.items():
             clean_inner_dict = {}
-            for inner_key, inner_val in val.items():
-                # Convert tuples to lists so they get written correctly
-                if isinstance(inner_val, tuple):
-                    clean_inner_dict.update({inner_key: list(inner_val)})
-                elif inner_val is not None:
-                    clean_inner_dict.update({inner_key: inner_val})
+            if isinstance(val, list):
+                for idx, list_val in enumerate(val):
+                    tmp_dict = {}
+                    for inner_key, inner_val in list_val.items():
+                        tmp_dict = convert_save_dict(tmp_dict, inner_val, inner_key)
+                    val[idx] = tmp_dict
+                clean_inner_dict = val
+            else:
+                for inner_key, inner_val in val.items():
+                    clean_inner_dict = convert_save_dict(clean_inner_dict, inner_val, inner_key)
             clean_dict.update({key: clean_inner_dict})
         if extra_info:
             clean_dict = add_info(clean_dict)
         return clean_dict
+
+    @staticmethod
+    def _convert(clean_inner_dict, inner_val, inner_key):
+        # Convert tuples to lists so they get written correctly
+        if isinstance(inner_val, tuple):
+            clean_inner_dict.update({inner_key: list(inner_val)})
+        elif inner_val is not None:
+            clean_inner_dict.update({inner_key: inner_val})
+        return clean_inner_dict
 
 
 class BaseBuilder(ABC):  # pylint: disable=too-few-public-methods
@@ -187,8 +215,15 @@ class BaseBuilder(ABC):  # pylint: disable=too-few-public-methods
         auto_dict = {}
         for attr_classes in self.input_classes:
             attr_build = self._auto_generate(dict_args, attr_classes)
-            auto_dict.update({type(attr_build).__name__: attr_build})
-        return argparse.Namespace(**auto_dict)
+            if isinstance(attr_build, list):
+                class_name = list({type(val).__name__ for val in attr_build})
+                if len(class_name) > 1:
+                    raise ValueError('Repeated class has more than one unique name')
+                auto_dict.update({class_name[0]: attr_build})
+            else:
+                auto_dict.update({type(attr_build).__name__: attr_build})
+        return Spockspace(**auto_dict)
+        # return argparse.Namespace(**auto_dict)
 
     def _auto_generate(self, args, input_class):
         """Builds an instance of a DataClass
@@ -207,7 +242,11 @@ class BaseBuilder(ABC):  # pylint: disable=too-few-public-methods
         """
         # Handle the basic data types
         fields = self._handle_arguments(args, input_class)
-        return input_class(**fields)
+        if isinstance(fields, list):
+            return_value = fields
+        else:
+            return_value = input_class(**fields)
+        return return_value
 
     def get_config_paths(self):
         """Get config paths from all methods
@@ -577,13 +616,14 @@ class BasePayload(ABC):  # pylint: disable=too-few-public-methods
         First checks to see if there is an existing dictionary to insert into, if not creates an empty one. Then it
         inserts the updated value at the correct dictionary level
 
-        Args:
+        *Args*:
+
             payload: current payload dictionary
             dict_key: dictionary key to check
             val_name: value name to update
             value: value to update
 
-        Returns:
+        *Returns*:
 
             payload: updated payload dictionary
 

--- a/spock/builder.py
+++ b/spock/builder.py
@@ -5,12 +5,12 @@
 
 """Handles the building/saving of the configurations from the Spock config classes"""
 
-from argparse import Namespace
-import attr
 from pathlib import Path
+import attr
 from spock.backend.attr.builder import AttrBuilder
 from spock.backend.attr.payload import AttrPayload
 from spock.backend.attr.saver import AttrSaver
+from spock.backend.base import Spockspace
 from spock.utils import check_payload_overwrite
 from spock.utils import deep_payload_update
 
@@ -74,9 +74,9 @@ class ConfigArgBuilder:
 
         """
         if unclass:
-            self._arg_namespace = Namespace(**{k: Namespace(**{
+            self._arg_namespace = Spockspace(**{k: Spockspace(**{
                 val.name: getattr(v, val.name) for val in v.__attrs_attrs__})
-                                               for k, v in self._arg_namespace.__dict__.items()})
+                                                for k, v in self._arg_namespace.__dict__.items()})
         return self._arg_namespace
 
     @staticmethod

--- a/spock/utils.py
+++ b/spock/utils.py
@@ -12,13 +12,35 @@ import subprocess
 import sys
 from time import localtime
 from time import strftime
-import git
 from warnings import warn
+import git
 minor = sys.version_info.minor
 if minor < 7:
     from typing import GenericMeta as _GenericAlias
 else:
     from typing import _GenericAlias
+
+
+def convert_save_dict(clean_inner_dict, inner_val, inner_key):
+    """Convert tuples in save dictionary
+
+    *Args*:
+
+        clean_inner_dict: inner dictionary that is clean
+        inner_val: inner value
+        inner_key:  inner key
+
+    *Returns*:
+
+        clean_inner_dict: updated with cleaned values
+
+    """
+    # Convert tuples to lists so they get written correctly
+    if isinstance(inner_val, tuple):
+        clean_inner_dict.update({inner_key: list(inner_val)})
+    elif inner_val is not None:
+        clean_inner_dict.update({inner_key: inner_val})
+    return clean_inner_dict
 
 
 def make_argument(arg_name, arg_type, parser):
@@ -108,10 +130,10 @@ def add_repo_info(out_dict):
         # Check if we are really in a detached head state as this will fail
         if minor < 7:
             head_result = subprocess.run('git rev-parse --abbrev-ref --symbolic-full-name HEAD', stdout=subprocess.PIPE,
-                                         shell=True)
+                                         shell=True, check=False)
         else:
             head_result = subprocess.run('git rev-parse --abbrev-ref --symbolic-full-name HEAD', capture_output=True,
-                                         shell=True)
+                                         shell=True, check=False)
         if head_result.stdout.decode().rstrip('\n') == 'HEAD':
             out_dict = make_blank_git(out_dict)
         else:

--- a/tests/attr/attr_configs_test.py
+++ b/tests/attr/attr_configs_test.py
@@ -38,6 +38,11 @@ class NestedListStuff:
     two: str
 
 
+class ClassChoice(Enum):
+    class_nested_stuff = NestedStuff
+    class_nested_list_stuff = NestedListStuff
+
+
 @spock
 class ChoiceFail:
     """This creates a test config to fail on an out of set choice"""
@@ -94,8 +99,10 @@ class TypeConfig:
     list_choice_p_float: List[FloatChoice]
     # Nested configuration
     nested: NestedStuff
-    # Nested list configutation
+    # Nested list configuration
     nested_list: List[NestedListStuff]
+    # Class Enum
+    class_enum: ClassChoice
 
 
 @spock
@@ -124,6 +131,18 @@ class TypeOptConfig:
     tuple_p_opt_no_def_str: Optional[Tuple[str]]
     # Optional Tuple default not set
     tuple_p_opt_no_def_bool: Optional[Tuple[bool]]
+    # Required choice -- Str
+    choice_p_opt_no_def_str: Optional[StrChoice]
+    # Required list of choice -- Str
+    list_choice_p_opt_no_def_str: Optional[List[StrChoice]]
+    # Required list of list of choice -- Str
+    list_list_choice_p_opt_no_def_str: Optional[List[List[StrChoice]]]
+    # Nested configuration
+    nested_opt_no_def: Optional[NestedStuff]
+    # Nested list configuration
+    nested_list_opt_no_def: Optional[List[NestedListStuff]]
+    # Class Enum
+    class_enum_opt_no_def: Optional[ClassChoice]
     # Additional dummy argument
     int_p: Optional[int]
 
@@ -159,6 +178,16 @@ class TypeDefaultConfig:
     tuple_p_bool_def: Tuple[bool] = (True, False)
     # Required choice
     choice_p_str_def: StrChoice = 'option_2'
+    # Required list of choice -- Str
+    list_choice_p_str_def: List[StrChoice] = ['option_1']
+    # Required list of list of choice -- Str
+    list_list_choice_p_str_def: List[List[StrChoice]] = [['option_1'], ['option_1']]
+    # Nested configuration
+    nested_def: NestedStuff = NestedStuff
+    # Nested list configuration
+    nested_list_def: List[NestedListStuff] = NestedListStuff
+    # Class Enum
+    class_enum_def: ClassChoice = NestedStuff
 
 
 @spock
@@ -187,6 +216,18 @@ class TypeDefaultOptConfig:
     tuple_p_opt_def_str: Optional[Tuple[str]] = ('Spock', 'Package')
     # Optional Tuple default set
     tuple_p_opt_def_bool: Optional[Tuple[bool]] = (True, False)
+    # Optional choice
+    choice_p_str_opt_def: Optional[StrChoice] = 'option_2'
+    # Optional list of choice -- Str
+    list_choice_p_str_opt_def: Optional[List[StrChoice]] = ['option_1']
+    # Optional list of list of choice -- Str
+    list_list_choice_p_str_opt_def: Optional[List[List[StrChoice]]] = [['option_1'], ['option_1']]
+    # Nested configuration
+    nested_opt_def: Optional[NestedStuff] = NestedStuff
+    # Nested list configuration
+    nested_list_opt_def: Optional[List[NestedListStuff]] = NestedListStuff
+    # Class Enum
+    class_enum_opt_def: Optional[ClassChoice] = NestedStuff
 
 
 @spock

--- a/tests/attr/attr_configs_test.py
+++ b/tests/attr/attr_configs_test.py
@@ -27,6 +27,18 @@ class FloatChoice(Enum):
 
 
 @spock
+class NestedStuff:
+    one: int
+    two: str
+
+
+@spock
+class NestedListStuff:
+    one: int
+    two: str
+
+
+@spock
 class ChoiceFail:
     """This creates a test config to fail on an out of set choice"""
     # Required choice -- Str
@@ -80,6 +92,10 @@ class TypeConfig:
     list_choice_p_int: List[IntChoice]
     # Required list of choice -- Float
     list_choice_p_float: List[FloatChoice]
+    # Nested configuration
+    nested: NestedStuff
+    # Nested list configutation
+    nested_list: List[NestedListStuff]
 
 
 @spock

--- a/tests/attr/test_all_attr.py
+++ b/tests/attr/test_all_attr.py
@@ -42,6 +42,8 @@ class AllTypes:
         assert arg_builder.TypeConfig.nested_list[0].two == 'hello'
         assert arg_builder.TypeConfig.nested_list[1].one == 20
         assert arg_builder.TypeConfig.nested_list[1].two == 'bye'
+        assert arg_builder.TypeConfig.class_enum.one == 11
+        assert arg_builder.TypeConfig.class_enum.two == 'ciao'
         # Optional #
         assert arg_builder.TypeOptConfig.int_p_opt_no_def is None
         assert arg_builder.TypeOptConfig.float_p_opt_no_def is None
@@ -54,6 +56,12 @@ class AllTypes:
         assert arg_builder.TypeOptConfig.tuple_p_opt_no_def_int is None
         assert arg_builder.TypeOptConfig.tuple_p_opt_no_def_str is None
         assert arg_builder.TypeOptConfig.tuple_p_opt_no_def_bool is None
+        assert arg_builder.TypeOptConfig.choice_p_opt_no_def_str is None
+        assert arg_builder.TypeOptConfig.list_choice_p_opt_no_def_str is None
+        assert arg_builder.TypeOptConfig.list_list_choice_p_opt_no_def_str is None
+        assert arg_builder.TypeOptConfig.nested_opt_no_def is None
+        assert arg_builder.TypeOptConfig.nested_list_opt_no_def is None
+        assert arg_builder.TypeOptConfig.class_enum_opt_no_def is None
 
 
 class AllDefaults:
@@ -72,6 +80,16 @@ class AllDefaults:
         assert arg_builder.TypeDefaultConfig.tuple_p_str_def == ('Spock', 'Package')
         assert arg_builder.TypeDefaultConfig.tuple_p_bool_def == (True, False)
         assert arg_builder.TypeDefaultConfig.choice_p_str_def == 'option_2'
+        assert arg_builder.TypeDefaultConfig.list_choice_p_str_def == ['option_1']
+        assert arg_builder.TypeDefaultConfig.list_list_choice_p_str_def == [['option_1'], ['option_1']]
+        assert arg_builder.TypeDefaultConfig.nested_def.one == 11
+        assert arg_builder.TypeDefaultConfig.nested_def.two == 'ciao'
+        assert arg_builder.TypeDefaultConfig.nested_list_def[0].one == 10
+        assert arg_builder.TypeDefaultConfig.nested_list_def[0].two == 'hello'
+        assert arg_builder.TypeDefaultConfig.nested_list_def[1].one == 20
+        assert arg_builder.TypeDefaultConfig.nested_list_def[1].two == 'bye'
+        assert arg_builder.TypeDefaultConfig.class_enum_def.one == 11
+        assert arg_builder.TypeDefaultConfig.class_enum_def.two == 'ciao'
         # Optional w/ Defaults #
         assert arg_builder.TypeDefaultOptConfig.int_p_opt_def == 10
         assert arg_builder.TypeDefaultOptConfig.float_p_opt_def == 10.0
@@ -84,6 +102,17 @@ class AllDefaults:
         assert arg_builder.TypeDefaultOptConfig.tuple_p_opt_def_int == (10, 20)
         assert arg_builder.TypeDefaultOptConfig.tuple_p_opt_def_str == ('Spock', 'Package')
         assert arg_builder.TypeDefaultOptConfig.tuple_p_opt_def_bool == (True, False)
+        assert arg_builder.TypeDefaultOptConfig.choice_p_str_opt_def == 'option_2'
+        assert arg_builder.TypeDefaultOptConfig.list_choice_p_str_opt_def == ['option_1']
+        assert arg_builder.TypeDefaultOptConfig.list_list_choice_p_str_opt_def == [['option_1'], ['option_1']]
+        assert arg_builder.TypeDefaultOptConfig.nested_opt_def.one == 11
+        assert arg_builder.TypeDefaultOptConfig.nested_opt_def.two == 'ciao'
+        assert arg_builder.TypeDefaultOptConfig.nested_list_opt_def[0].one == 10
+        assert arg_builder.TypeDefaultOptConfig.nested_list_opt_def[0].two == 'hello'
+        assert arg_builder.TypeDefaultOptConfig.nested_list_opt_def[1].one == 20
+        assert arg_builder.TypeDefaultOptConfig.nested_list_opt_def[1].two == 'bye'
+        assert arg_builder.TypeDefaultOptConfig.class_enum_opt_def.one == 11
+        assert arg_builder.TypeDefaultOptConfig.class_enum_opt_def.two == 'ciao'
 
 
 class AllInherited:
@@ -110,6 +139,14 @@ class AllInherited:
         assert arg_builder.TypeInherited.list_list_choice_p_str == [['option_1'], ['option_1']]
         assert arg_builder.TypeInherited.list_choice_p_int == [10]
         assert arg_builder.TypeInherited.list_choice_p_float == [10.0]
+        assert arg_builder.TypeInherited.nested.one == 11
+        assert arg_builder.TypeInherited.nested.two == 'ciao'
+        assert arg_builder.TypeInherited.nested_list[0].one == 10
+        assert arg_builder.TypeInherited.nested_list[0].two == 'hello'
+        assert arg_builder.TypeInherited.nested_list[1].one == 20
+        assert arg_builder.TypeInherited.nested_list[1].two == 'bye'
+        assert arg_builder.TypeInherited.class_enum.one == 11
+        assert arg_builder.TypeInherited.class_enum.two == 'ciao'
         # Optional w/ Defaults #
         assert arg_builder.TypeInherited.int_p_opt_def == 10
         assert arg_builder.TypeInherited.float_p_opt_def == 10.0

--- a/tests/attr/test_all_attr.py
+++ b/tests/attr/test_all_attr.py
@@ -36,6 +36,12 @@ class AllTypes:
         assert arg_builder.TypeConfig.list_list_choice_p_str == [['option_1'], ['option_1']]
         assert arg_builder.TypeConfig.list_choice_p_int == [10]
         assert arg_builder.TypeConfig.list_choice_p_float == [10.0]
+        assert arg_builder.TypeConfig.nested.one == 11
+        assert arg_builder.TypeConfig.nested.two == 'ciao'
+        assert arg_builder.TypeConfig.nested_list[0].one == 10
+        assert arg_builder.TypeConfig.nested_list[0].two == 'hello'
+        assert arg_builder.TypeConfig.nested_list[1].one == 20
+        assert arg_builder.TypeConfig.nested_list[1].two == 'bye'
         # Optional #
         assert arg_builder.TypeOptConfig.int_p_opt_no_def is None
         assert arg_builder.TypeOptConfig.float_p_opt_no_def is None
@@ -128,7 +134,7 @@ class TestAllTypesYAML(AllTypes):
         with monkeypatch.context() as m:
             m.setattr(sys, 'argv', ['', '--config',
                                     './tests/conf/yaml/test.yaml'])
-            config = ConfigArgBuilder(TypeConfig, TypeOptConfig, desc='Test Builder')
+            config = ConfigArgBuilder(TypeConfig, NestedStuff, NestedListStuff, TypeOptConfig, desc='Test Builder')
             return config.generate()
 
 
@@ -140,7 +146,8 @@ class TestAllDefaultsYAML(AllDefaults):
         with monkeypatch.context() as m:
             m.setattr(sys, 'argv', ['', '--config',
                                     './tests/conf/yaml/test.yaml'])
-            config = ConfigArgBuilder(TypeConfig, TypeOptConfig, TypeDefaultConfig, TypeDefaultOptConfig,
+            config = ConfigArgBuilder(TypeConfig, NestedStuff, NestedListStuff, TypeOptConfig, TypeDefaultConfig,
+                                      TypeDefaultOptConfig,
                                       desc='Test Builder')
             return config.generate()
 
@@ -153,7 +160,7 @@ class TestFrozen:
         with monkeypatch.context() as m:
             m.setattr(sys, 'argv', ['', '--config',
                                     './tests/conf/yaml/test.yaml'])
-            config = ConfigArgBuilder(TypeConfig, TypeOptConfig, desc='Test Builder')
+            config = ConfigArgBuilder(TypeConfig, NestedStuff, NestedListStuff, TypeOptConfig, desc='Test Builder')
             return config.generate()
 
     # Check frozen state works
@@ -187,7 +194,7 @@ class TestGeneralCmdLineOverride:
                                     '--list_list_choice_p_str', "[['option_2'], ['option_2']]",
                                     '--list_choice_p_int', '[20]', '--list_choice_p_float', '[20.0]'
                                     ])
-            config = ConfigArgBuilder(TypeConfig, desc='Test Builder')
+            config = ConfigArgBuilder(TypeConfig, NestedStuff, NestedListStuff, desc='Test Builder')
             return config.generate()
 
     def test_overrides(self, arg_builder):
@@ -219,7 +226,7 @@ class TestConfigKwarg(AllTypes):
     @pytest.fixture
     def arg_builder(monkeypatch):
         with monkeypatch.context() as m:
-            config = ConfigArgBuilder(TypeConfig, TypeOptConfig, desc='Test Builder',
+            config = ConfigArgBuilder(TypeConfig, NestedStuff, NestedListStuff, TypeOptConfig, desc='Test Builder',
                                       configs=['./tests/conf/yaml/test.yaml'])
             return config.generate()
 
@@ -230,7 +237,7 @@ class TestNoCmdLineKwarg(AllTypes):
     @pytest.fixture
     def arg_builder(monkeypatch):
         with monkeypatch.context() as m:
-            config = ConfigArgBuilder(TypeConfig, TypeOptConfig, no_cmd_line=True,
+            config = ConfigArgBuilder(TypeConfig, NestedStuff, NestedListStuff, TypeOptConfig, no_cmd_line=True,
                                       configs=['./tests/conf/yaml/test.yaml'])
             return config.generate()
 
@@ -240,7 +247,7 @@ class TestNoCmdLineRaise:
     def test_choice_raise(self, monkeypatch):
         with monkeypatch.context() as m:
             with pytest.raises(ValueError):
-                ConfigArgBuilder(TypeConfig, TypeOptConfig, no_cmd_line=True)
+                ConfigArgBuilder(TypeConfig, NestedStuff, NestedListStuff, TypeOptConfig, no_cmd_line=True)
 
 
 class TestComposition:
@@ -251,7 +258,7 @@ class TestComposition:
         with monkeypatch.context() as m:
             m.setattr(sys, 'argv', ['', '--config',
                                     './tests/conf/yaml/test_include.yaml'])
-            config = ConfigArgBuilder(TypeConfig, TypeOptConfig, desc='Test Builder')
+            config = ConfigArgBuilder(TypeConfig, NestedStuff, NestedListStuff, TypeOptConfig, desc='Test Builder')
             return config.generate()
 
     def test_req_int(self, arg_builder):
@@ -266,7 +273,7 @@ class TestInheritance(AllInherited):
         with monkeypatch.context() as m:
             m.setattr(sys, 'argv', ['', '--config',
                                     './tests/conf/yaml/inherited.yaml'])
-            config = ConfigArgBuilder(TypeInherited, desc='Test Builder')
+            config = ConfigArgBuilder(TypeInherited, NestedStuff, NestedListStuff, desc='Test Builder')
             return config.generate()
 
 
@@ -287,7 +294,7 @@ class TestOverrideRaise:
             m.setattr(sys, 'argv', ['', '--config',
                                     './tests/conf/yaml/test.yaml'])
             with pytest.raises(ValueError):
-                ConfigArgBuilder(TypeInherited, desc='Test Builder')
+                ConfigArgBuilder(TypeInherited, NestedStuff, NestedListStuff, desc='Test Builder')
 
 
 class TestConfigArgType:
@@ -306,7 +313,7 @@ class TestUnknownArg:
             m.setattr(sys, 'argv', ['', '--config',
                                     './tests/conf/yaml/test_incorrect.yaml'])
             with pytest.raises(ValueError):
-                ConfigArgBuilder(TypeConfig, desc='Test Builder')
+                ConfigArgBuilder(TypeConfig, NestedStuff, NestedListStuff, desc='Test Builder')
 
 
 class TestConfigCycles:
@@ -316,7 +323,7 @@ class TestConfigCycles:
             m.setattr(sys, 'argv', ['', '--config',
                                     './tests/conf/yaml/test_cycle.yaml'])
             with pytest.raises(ValueError):
-                ConfigArgBuilder(TypeConfig, desc='Test Builder')
+                ConfigArgBuilder(TypeConfig, NestedStuff, NestedListStuff, desc='Test Builder')
 
 
 class TestConfigDuplicate:
@@ -326,7 +333,7 @@ class TestConfigDuplicate:
             m.setattr(sys, 'argv', ['', '--config',
                                     './tests/conf/yaml/test_duplicate.yaml', './tests/conf/yaml/test.yaml'])
             with pytest.raises(ValueError):
-                ConfigArgBuilder(TypeConfig, desc='Test Builder')
+                ConfigArgBuilder(TypeConfig, NestedStuff, NestedListStuff, desc='Test Builder')
 
 
 class TestDefaultWriter:
@@ -335,7 +342,7 @@ class TestDefaultWriter:
         with monkeypatch.context() as m:
             m.setattr(sys, 'argv', ['', '--config',
                                     './tests/conf/yaml/test.yaml'])
-            config = ConfigArgBuilder(TypeConfig, TypeOptConfig, desc='Test Builder')
+            config = ConfigArgBuilder(TypeConfig, NestedStuff, NestedListStuff, TypeOptConfig, desc='Test Builder')
             # Test the chained version
             config.save(user_specified_path=tmp_path).generate()
             assert len(list(tmp_path.iterdir())) == 1
@@ -347,7 +354,7 @@ class TestYAMLWriter:
         with monkeypatch.context() as m:
             m.setattr(sys, 'argv', ['', '--config',
                                     './tests/conf/yaml/test.yaml'])
-            config = ConfigArgBuilder(TypeConfig, TypeOptConfig, desc='Test Builder')
+            config = ConfigArgBuilder(TypeConfig, NestedStuff, NestedListStuff, TypeOptConfig, desc='Test Builder')
             # Test the chained version
             config.save(user_specified_path=tmp_path, file_extension='.yaml').generate()
             check_path = str(tmp_path) + '/*.yaml'
@@ -363,7 +370,7 @@ class TestWritePathRaise:
         with monkeypatch.context() as m:
             m.setattr(sys, 'argv', ['', '--config',
                                     './tests/conf/yaml/test.yaml'])
-            config = ConfigArgBuilder(TypeConfig, TypeOptConfig, desc='Test Builder')
+            config = ConfigArgBuilder(TypeConfig, NestedStuff, NestedListStuff, TypeOptConfig, desc='Test Builder')
             # Test the chained version
             with pytest.raises(FileNotFoundError):
                 config.save(user_specified_path=str(tmp_path)+'/foo.bar/fizz.buzz/', file_extension='.yaml').generate()
@@ -378,7 +385,7 @@ class TestAllTypesTOML(AllTypes):
         with monkeypatch.context() as m:
             m.setattr(sys, 'argv', ['', '--config',
                                     './tests/conf/toml/test.toml'])
-            config = ConfigArgBuilder(TypeConfig, TypeOptConfig, desc='Test Builder')
+            config = ConfigArgBuilder(TypeConfig, NestedStuff, NestedListStuff, TypeOptConfig, desc='Test Builder')
             return config.generate()
 
 
@@ -390,7 +397,7 @@ class TestAllDefaultsTOML(AllDefaults):
         with monkeypatch.context() as m:
             m.setattr(sys, 'argv', ['', '--config',
                                     './tests/conf/toml/test.toml'])
-            config = ConfigArgBuilder(TypeConfig, TypeOptConfig, TypeDefaultConfig, TypeDefaultOptConfig,
+            config = ConfigArgBuilder(TypeConfig, NestedStuff, NestedListStuff, TypeOptConfig, TypeDefaultConfig, TypeDefaultOptConfig,
                                       desc='Test Builder')
             return config.generate()
 
@@ -401,7 +408,7 @@ class TestTOMLWriter:
         with monkeypatch.context() as m:
             m.setattr(sys, 'argv', ['', '--config',
                                     './tests/conf/toml/test.toml'])
-            config = ConfigArgBuilder(TypeConfig, TypeOptConfig, desc='Test Builder')
+            config = ConfigArgBuilder(TypeConfig, NestedStuff, NestedListStuff, TypeOptConfig, desc='Test Builder')
             # Test the chained version
             config.save(user_specified_path=tmp_path, file_extension='.toml').generate()
             check_path = str(tmp_path) + '/*.toml'
@@ -420,7 +427,7 @@ class TestAllTypesJSON(AllTypes):
         with monkeypatch.context() as m:
             m.setattr(sys, 'argv', ['', '--config',
                                     './tests/conf/json/test.json'])
-            config = ConfigArgBuilder(TypeConfig, TypeOptConfig, desc='Test Builder')
+            config = ConfigArgBuilder(TypeConfig, NestedStuff, NestedListStuff, TypeOptConfig, desc='Test Builder')
             return config.generate()
 
 
@@ -432,7 +439,7 @@ class TestAllDefaultsJSON(AllDefaults):
         with monkeypatch.context() as m:
             m.setattr(sys, 'argv', ['', '--config',
                                     './tests/conf/json/test.json'])
-            config = ConfigArgBuilder(TypeConfig, TypeOptConfig, TypeDefaultConfig, TypeDefaultOptConfig,
+            config = ConfigArgBuilder(TypeConfig, NestedStuff, NestedListStuff, TypeOptConfig, TypeDefaultConfig, TypeDefaultOptConfig,
                                       desc='Test Builder')
             return config.generate()
 
@@ -443,7 +450,7 @@ class TestJSONWriter:
         with monkeypatch.context() as m:
             m.setattr(sys, 'argv', ['', '--config',
                                     './tests/conf/json/test.json'])
-            config = ConfigArgBuilder(TypeConfig, TypeOptConfig, desc='Test Builder')
+            config = ConfigArgBuilder(TypeConfig, NestedStuff, NestedListStuff, TypeOptConfig, desc='Test Builder')
             # Test the chained version
             config.save(user_specified_path=tmp_path, file_extension='.json').generate()
             check_path = str(tmp_path) + '/*.json'

--- a/tests/conf/json/test.json
+++ b/tests/conf/json/test.json
@@ -34,6 +34,7 @@
       "two": "bye"
     }
   ],
+  "class_enum": "NestedStuff",
   "TypeConfig": {
     "float_p": 12.0
   }

--- a/tests/conf/json/test.json
+++ b/tests/conf/json/test.json
@@ -19,6 +19,21 @@
   "list_list_choice_p_str": [["option_1"], ["option_1"]],
   "list_choice_p_int": [10],
   "list_choice_p_float": [10.0],
+  "nested": "NestedStuff",
+  "NestedStuff": {
+    "one": 11,
+    "two": "ciao"
+  },
+  "nested_list": "NestedListStuff",
+  "NestedListStuff": [
+    {
+      "one": 10,
+      "two": "hello"
+    }, {
+      "one": 20,
+      "two": "bye"
+    }
+  ],
   "TypeConfig": {
     "float_p": 12.0
   }

--- a/tests/conf/toml/test.toml
+++ b/tests/conf/toml/test.toml
@@ -45,6 +45,8 @@ NestedStuff = {one = 11, two = 'ciao'}
 # Nested List configuration
 nested_list = 'NestedListStuff'
 NestedListStuff = [{one = 10, two = 'hello'}, {one = 20, two = 'bye'}]
+# Class Enum
+class_enum = 'NestedStuff'
 # Overrride general definition
 [TypeConfig]
     float_p = 12.0

--- a/tests/conf/toml/test.toml
+++ b/tests/conf/toml/test.toml
@@ -39,6 +39,12 @@ list_list_choice_p_str = [['option_1'], ['option_1']]
 list_choice_p_int = [10]
 # Required List of Choice -- Float
 list_choice_p_float = [10.0]
+# Nested Configuration
+nested = 'NestedStuff'
+NestedStuff = {one = 11, two = 'ciao'}
+# Nested List configuration
+nested_list = 'NestedListStuff'
+NestedListStuff = [{one = 10, two = 'hello'}, {one = 20, two = 'bye'}]
 # Overrride general definition
 [TypeConfig]
     float_p = 12.0

--- a/tests/conf/yaml/inherited.yaml
+++ b/tests/conf/yaml/inherited.yaml
@@ -52,3 +52,5 @@ NestedListStuff:
       two: hello
     - one: 20
       two: bye
+# Class Enum
+class_enum: NestedStuff

--- a/tests/conf/yaml/inherited.yaml
+++ b/tests/conf/yaml/inherited.yaml
@@ -40,3 +40,15 @@ list_list_choice_p_str: [[option_1], [option_1]]
 list_choice_p_int: [10]
 # Required List of Choice -- Float
 list_choice_p_float: [10.0]
+# Nested Configuration
+nested: NestedStuff
+NestedStuff:
+    one: 11
+    two: ciao
+# Nested List configuration
+nested_list: NestedListStuff
+NestedListStuff:
+    - one: 10
+      two: hello
+    - one: 20
+      two: bye

--- a/tests/conf/yaml/test.yaml
+++ b/tests/conf/yaml/test.yaml
@@ -52,6 +52,8 @@ NestedListStuff:
       two: hello
     - one: 20
       two: bye
+# Class Enum
+class_enum: NestedStuff
 # Override general definition
 TypeConfig:
     float_p: 12.0

--- a/tests/conf/yaml/test.yaml
+++ b/tests/conf/yaml/test.yaml
@@ -40,6 +40,18 @@ list_list_choice_p_str: [[option_1], [option_1]]
 list_choice_p_int: [10]
 # Required List of Choice -- Float
 list_choice_p_float: [10.0]
+# Nested Configuration
+nested: NestedStuff
+NestedStuff:
+    one: 11
+    two: ciao
+# Nested List configuration
+nested_list: NestedListStuff
+NestedListStuff:
+    - one: 10
+      two: hello
+    - one: 20
+      two: bye
 # Override general definition
 TypeConfig:
     float_p: 12.0

--- a/tests/debug/debug.py
+++ b/tests/debug/debug.py
@@ -18,6 +18,12 @@ class Choice(Enum):
 
 
 @spock
+class OtherStuff:
+    three: int
+    four: str
+
+
+@spock
 class Stuff:
     one: int
     two: str
@@ -31,9 +37,10 @@ class Test:
     # # fail: bool
     # # fail: List
     test: List[int]
-    # fail: List[List[int]]
+    fail: List[List[int]]
     # borken: Stuff
     borken: List[Stuff]
+    more_borken: OtherStuff
     # borken: int
     # borken: Optional[List[List[Choice]]] = [['pear'], ['banana']]
     # save_path: SavePath = '/tmp'
@@ -55,16 +62,16 @@ class Test:
 
 
 def main():
-    # attrs_class = ConfigArgBuilder(Test, Stuff).generate()
+    attrs_class = ConfigArgBuilder(Test, OtherStuff, Stuff).generate()
     # with open('/tmp/debug.pickle', 'wb') as fid:
     #     pickle.dump(attrs_class, file=fid)
 
-    with open('/tmp/debug.pickle', 'rb') as fid:
-        attrs_load = pickle.load(fid)
+    # with open('/tmp/debug.pickle', 'rb') as fid:
+    #     attrs_load = pickle.load(fid)
     # attrs_class = ConfigArgBuilder(Test, Test2).generate()
 
-    # print(attrs_class)
-    print(attrs_load)
+    print(attrs_class)
+    # print(attrs_load)
     # dc_class = ConfigArgBuilder(OldInherit).generate()
     # print(dc_class)
 

--- a/tests/debug/debug.py
+++ b/tests/debug/debug.py
@@ -18,15 +18,24 @@ class Choice(Enum):
 
 
 @spock
+class Stuff:
+    one: int
+    two: str
+
+
+@spock
 class Test:
-    new_choice: Choice
+    # new_choice: Choice
     # # fix_me: Tuple[Tuple[int]]
     # new: int
     # # fail: bool
     # # fail: List
-    # test: List[int]
+    test: List[int]
     # fail: List[List[int]]
-    borken: Optional[List[List[Choice]]] = [['pear'], ['banana']]
+    # borken: Stuff
+    borken: List[Stuff]
+    # borken: int
+    # borken: Optional[List[List[Choice]]] = [['pear'], ['banana']]
     # save_path: SavePath = '/tmp'
     # other: Optional[int]
     # value: Optional[List[int]] = [1, 2]
@@ -46,9 +55,9 @@ class Test:
 
 
 def main():
-    attrs_class = ConfigArgBuilder(Test).generate()
-    with open('/tmp/debug.pickle', 'wb') as fid:
-        pickle.dump(attrs_class, file=fid)
+    # attrs_class = ConfigArgBuilder(Test, Stuff).generate()
+    # with open('/tmp/debug.pickle', 'wb') as fid:
+    #     pickle.dump(attrs_class, file=fid)
 
     with open('/tmp/debug.pickle', 'rb') as fid:
         attrs_load = pickle.load(fid)

--- a/tests/debug/debug.py
+++ b/tests/debug/debug.py
@@ -17,6 +17,11 @@ class Choice(Enum):
     banana = 'banana'
 
 
+class IntChoice(Enum):
+    option_1 = 10
+    option_2 = 20
+
+
 @spock
 class OtherStuff:
     three: int
@@ -29,18 +34,25 @@ class Stuff:
     two: str
 
 
+class ClassStuff(Enum):
+    other_stuff = OtherStuff
+    stuff = Stuff
+
+
+
 @spock
 class Test:
-    # new_choice: Choice
+    # new_choice: Optional[Choice]
     # # fix_me: Tuple[Tuple[int]]
-    # new: int
-    # # fail: bool
-    # # fail: List
-    test: List[int]
-    fail: List[List[int]]
-    # borken: Stuff
-    borken: List[Stuff]
-    more_borken: OtherStuff
+    # new: int = 3
+    # fail: bool
+    # fail: List
+    # test: List[int] = [1, 2]
+    # fail: List[List[int]] = [[1, 2], [1, 2]]
+    # borken: Stuff = Stuff
+    # borken: List[Stuff] = Stuff
+    # more_borken: OtherStuff
+    most_broken: ClassStuff = Stuff
     # borken: int
     # borken: Optional[List[List[Choice]]] = [['pear'], ['banana']]
     # save_path: SavePath = '/tmp'

--- a/tests/debug/debug.yaml
+++ b/tests/debug/debug.yaml
@@ -1,38 +1,41 @@
 #other: 1
 #new_other: 1
 #config: [debug_inherit.yaml]
-fail: [[1, 2], [2, 1]]
-##value: [1, 2]
-##fix_me: [[1, 2], [2, 1]]
-##Test:
-##    fix_me: [[11, 2], [22, 1]]
-#new_choice: pear
-borken: Stuff
+#fail: [[1, 2], [2, 1]]
+###value: [1, 2]
+###fix_me: [[1, 2], [2, 1]]
+###Test:
+###    fix_me: [[11, 2], [22, 1]]
+##new_choice: pear
+#borken: Stuff
 Stuff:
-#  one: 10
-#  two: hello
-  - one: 10
-    two: hello
-  - one: 20
-    two: bye
+  one: 10
+  two: hello
+#  - one: 10
+#    two: hello
+#  - one: 20
+#    two: bye
 
-more_borken: OtherStuff
+#more_borken: OtherStuff
 OtherStuff:
   three: 20
   four: ciao
-#Test2:
-##    other: 12
-##Test:
-##    new: 12
-##fail: false
-##ccccombo_breaker: 10
-#new: 1
-#other: 1
-#Test2:
-#  fail: 2
-#  other: 3
-##fail: 1
-test: [1, 2]
+###Test2:
+###    other: 12
+###Test:
+###    new: 12
+###fail: false
+###ccccombo_breaker: 10
+#new: 10
+##other: 1
+##Test2:
+##  fail: 2
+##  other: 3
+###fail: 1
+#test: [1, 2]
+
+#most_broken: OtherStuff
+
 #save_path: /tmp
 #new_choice: pear
 #borken: [[pear], [pear, banana]]
@@ -42,4 +45,4 @@ test: [1, 2]
 #    other: 12
 #ccccombo_breaker: 10
 #new: 1
-#fail: 1
+#fail: true

--- a/tests/debug/debug.yaml
+++ b/tests/debug/debug.yaml
@@ -1,7 +1,7 @@
 #other: 1
 #new_other: 1
 #config: [debug_inherit.yaml]
-#fail: [[1, 2], [2, 1]]
+fail: [[1, 2], [2, 1]]
 ##value: [1, 2]
 ##fix_me: [[1, 2], [2, 1]]
 ##Test:
@@ -15,6 +15,11 @@ Stuff:
     two: hello
   - one: 20
     two: bye
+
+more_borken: OtherStuff
+OtherStuff:
+  three: 20
+  four: ciao
 #Test2:
 ##    other: 12
 ##Test:

--- a/tests/debug/debug.yaml
+++ b/tests/debug/debug.yaml
@@ -6,7 +6,15 @@
 ##fix_me: [[1, 2], [2, 1]]
 ##Test:
 ##    fix_me: [[11, 2], [22, 1]]
-new_choice: pear
+#new_choice: pear
+borken: Stuff
+Stuff:
+#  one: 10
+#  two: hello
+  - one: 10
+    two: hello
+  - one: 20
+    two: bye
 #Test2:
 ##    other: 12
 ##Test:
@@ -19,8 +27,8 @@ new_choice: pear
 #  fail: 2
 #  other: 3
 ##fail: 1
-##test: [1, 2]
-##save_path: /tmp
+test: [1, 2]
+#save_path: /tmp
 #new_choice: pear
 #borken: [[pear], [pear, banana]]
 #Test2:


### PR DESCRIPTION
Resolves #6. 

@sidnarayanan any chance I could borrow you to test this and see if it makes sense?

Example:

Spock class defs

```python
@spock
class OtherStuff:
    three: int
    four: str


@spock
class Stuff:
    one: int
    two: str


@spock
class Test:
    test: List[int]
    fail: List[List[int]]
    borken: List[Stuff]
    more_borken: OtherStuff

```

YAML markup

```yaml
fail: [[1, 2], [2, 1]]
borken: Stuff
Stuff:
  - one: 10
    two: hello
  - one: 20
    two: bye
more_borken: OtherStuff
OtherStuff:
  three: 20
  four: ciao
test: [1, 2]
```

The nested configuration is represented by a list in the corresponding Namespace (ie Test.borken --> list of Stuff type that is iterable and the values of Stuff are accessible with . notation)

