### PR TITLE
Fixes Enums of class type

### DIFF
--- a/spock/backend/attr/builder.py
+++ b/spock/backend/attr/builder.py
@@ -111,13 +111,14 @@ class AttrBuilder(BaseBuilder):
             if len(match_idx) > 1:
                 raise ValueError('Match error -- multiple classes with the same name definition')
             else:
+                if args.get(self.input_classes[match_idx[0]].__name__) is None:
+                    raise ValueError(f'Missing config file definition for the referenced class '
+                                     f'{self.input_classes[match_idx[0]].__name__}')
                 current_arg = args.get(self.input_classes[match_idx[0]].__name__)
                 if isinstance(current_arg, list):
                     class_value = [self.input_classes[match_idx[0]](**val) for val in current_arg]
                 else:
-                    class_value = self.input_classes[match_idx[0]](
-                        **args.get(self.input_classes[match_idx[0]].__name__)
-                    )
+                    class_value = self.input_classes[match_idx[0]](**current_arg)
             return_value = class_value
         # else return the expected value
         else:

--- a/spock/backend/attr/typed.py
+++ b/spock/backend/attr/typed.py
@@ -6,7 +6,9 @@
 """Handles the definitions of arguments types for Spock (backend: attrs)"""
 
 import sys
+from enum import Enum
 from enum import EnumMeta
+from functools import partial
 from typing import TypeVar
 from typing import Union
 import attr
@@ -168,6 +170,34 @@ def _enum_katra(typed, default=None, optional=False):
     """
     # First check if the types of Enum are the same
     base_type, allowed = _check_enum_props(typed)
+    if isinstance(base_type, type):
+        x = _enum_class_katra(typed=typed, allowed=allowed, default=default, optional=optional)
+    else:
+        x = _enum_base_katra(typed=typed, base_type=base_type, allowed=allowed, default=default, optional=optional)
+    return x
+
+
+def _enum_base_katra(typed, base_type, allowed, default=None, optional=False):
+    """Private interface to create a base Enum typed katra
+
+    Here we handle the base types of enums that allows us to force a type check on the instance
+
+    A 'katra' is the basic functional unit of `spock`. It defines a parameter using attrs as the backend, type checks
+    both simple types and subscripted GenericAlias types (e.g. lists and tuples), handles setting default parameters,
+    and deals with parameter optionality
+
+    *Args*:
+        typed: the type of the parameter to define
+        base_type: underlying base type
+        allowed: set of allowed values
+        default: the default value to assign if given
+        optional: whether to make the parameter optional or not (thus allowing None)
+
+    *Returns*:
+
+        x: Attribute from attrs
+
+    """
     if default is not None:
         x = attr.ib(
             validator=[attr.validators.instance_of(base_type), attr.validators.in_(allowed)],
@@ -179,6 +209,61 @@ def _enum_katra(typed, default=None, optional=False):
     else:
         x = attr.ib(validator=[attr.validators.instance_of(base_type), attr.validators.in_(allowed)], type=typed,
                     metadata={'base': typed.__name__})
+    return x
+
+
+def _in_type(instance, attribute, value, options):
+    """attrs validator for class type enum
+
+    Checks if the type of the class (e.g. value) is in the specified set of types provided
+
+    *Args*:
+
+        instance: current object instance
+        attribute: current attribute instance
+        value: current value trying to be set in the attrs instance
+        options: list, tuple, or enum of allowed options
+
+    *Returns*:
+
+    """
+    if type(options) not in [list, tuple, Enum]:
+        raise TypeError(f'options argument must be of type List, Tuple, or Enum -- given {type(options)}')
+    if type(value) not in options:
+        raise ValueError(f'{attribute.name} must be in {options}')
+
+
+def _enum_class_katra(typed, allowed, default=None, optional=False):
+    """Private interface to create a base Enum typed katra
+
+    Here we handle the class based types of enums. Seeing as these classes are generated dynamically we cannot
+    force type checking of a specific instance however the in_ validator will catch an incorrect instance type
+
+    A 'katra' is the basic functional unit of `spock`. It defines a parameter using attrs as the backend, type checks
+    both simple types and subscripted GenericAlias types (e.g. lists and tuples), handles setting default parameters,
+    and deals with parameter optionality
+
+    *Args*:
+
+        typed: the type of the parameter to define
+        allowed: set of allowed values
+        default: the default value to assign if given
+        optional: whether to make the parameter optional or not (thus allowing None)
+
+    *Returns*:
+
+        x: Attribute from attrs
+
+    """
+    if default is not None:
+        x = attr.ib(
+            validator=[partial(_in_type, options=allowed)], default=default, metadata={'base': typed.__name__})
+    elif optional:
+        x = attr.ib(
+            validator=attr.validators.optional([partial(_in_type, options=allowed)]),
+            default=default, metadata={'base': typed.__name__})
+    else:
+        x = attr.ib(validator=[partial(_in_type, options=allowed)], metadata={'base': typed.__name__})
     return x
 
 

--- a/spock/backend/attr/typed.py
+++ b/spock/backend/attr/typed.py
@@ -6,7 +6,6 @@
 """Handles the definitions of arguments types for Spock (backend: attrs)"""
 
 import sys
-from enum import Enum
 from enum import EnumMeta
 from functools import partial
 from typing import TypeVar
@@ -170,7 +169,7 @@ def _enum_katra(typed, default=None, optional=False):
     """
     # First check if the types of Enum are the same
     base_type, allowed = _check_enum_props(typed)
-    if isinstance(base_type, type):
+    if base_type.__name__ == 'type':
         x = _enum_class_katra(typed=typed, allowed=allowed, default=default, optional=optional)
     else:
         x = _enum_base_katra(typed=typed, base_type=base_type, allowed=allowed, default=default, optional=optional)
@@ -227,7 +226,7 @@ def _in_type(instance, attribute, value, options):
     *Returns*:
 
     """
-    if type(options) not in [list, tuple, Enum]:
+    if type(options) not in [list, tuple, EnumMeta]:
         raise TypeError(f'options argument must be of type List, Tuple, or Enum -- given {type(options)}')
     if type(value) not in options:
         raise ValueError(f'{attribute.name} must be in {options}')

--- a/tests/attr/attr_configs_test.py
+++ b/tests/attr/attr_configs_test.py
@@ -38,6 +38,11 @@ class NestedListStuff:
     two: str
 
 
+class ClassChoice(Enum):
+    class_nested_stuff = NestedStuff
+    class_nested_list_stuff = NestedListStuff
+
+
 @spock
 class ChoiceFail:
     """This creates a test config to fail on an out of set choice"""
@@ -94,8 +99,10 @@ class TypeConfig:
     list_choice_p_float: List[FloatChoice]
     # Nested configuration
     nested: NestedStuff
-    # Nested list configutation
+    # Nested list configuration
     nested_list: List[NestedListStuff]
+    # Class Enum
+    class_enum: ClassChoice
 
 
 @spock
@@ -124,6 +131,18 @@ class TypeOptConfig:
     tuple_p_opt_no_def_str: Optional[Tuple[str]]
     # Optional Tuple default not set
     tuple_p_opt_no_def_bool: Optional[Tuple[bool]]
+    # Required choice -- Str
+    choice_p_opt_no_def_str: Optional[StrChoice]
+    # Required list of choice -- Str
+    list_choice_p_opt_no_def_str: Optional[List[StrChoice]]
+    # Required list of list of choice -- Str
+    list_list_choice_p_opt_no_def_str: Optional[List[List[StrChoice]]]
+    # Nested configuration
+    nested_opt_no_def: Optional[NestedStuff]
+    # Nested list configuration
+    nested_list_opt_no_def: Optional[List[NestedListStuff]]
+    # Class Enum
+    class_enum_opt_no_def: Optional[ClassChoice]
     # Additional dummy argument
     int_p: Optional[int]
 
@@ -159,6 +178,16 @@ class TypeDefaultConfig:
     tuple_p_bool_def: Tuple[bool] = (True, False)
     # Required choice
     choice_p_str_def: StrChoice = 'option_2'
+    # Required list of choice -- Str
+    list_choice_p_str_def: List[StrChoice] = ['option_1']
+    # Required list of list of choice -- Str
+    list_list_choice_p_str_def: List[List[StrChoice]] = [['option_1'], ['option_1']]
+    # Nested configuration
+    nested_def: NestedStuff = NestedStuff
+    # Nested list configuration
+    nested_list_def: List[NestedListStuff] = NestedListStuff
+    # Class Enum
+    class_enum_def: ClassChoice = NestedStuff
 
 
 @spock
@@ -187,6 +216,18 @@ class TypeDefaultOptConfig:
     tuple_p_opt_def_str: Optional[Tuple[str]] = ('Spock', 'Package')
     # Optional Tuple default set
     tuple_p_opt_def_bool: Optional[Tuple[bool]] = (True, False)
+    # Optional choice
+    choice_p_str_opt_def: Optional[StrChoice] = 'option_2'
+    # Optional list of choice -- Str
+    list_choice_p_str_opt_def: Optional[List[StrChoice]] = ['option_1']
+    # Optional list of list of choice -- Str
+    list_list_choice_p_str_opt_def: Optional[List[List[StrChoice]]] = [['option_1'], ['option_1']]
+    # Nested configuration
+    nested_opt_def: Optional[NestedStuff] = NestedStuff
+    # Nested list configuration
+    nested_list_opt_def: Optional[List[NestedListStuff]] = NestedListStuff
+    # Class Enum
+    class_enum_opt_def: Optional[ClassChoice] = NestedStuff
 
 
 @spock

--- a/tests/attr/test_all_attr.py
+++ b/tests/attr/test_all_attr.py
@@ -42,6 +42,8 @@ class AllTypes:
         assert arg_builder.TypeConfig.nested_list[0].two == 'hello'
         assert arg_builder.TypeConfig.nested_list[1].one == 20
         assert arg_builder.TypeConfig.nested_list[1].two == 'bye'
+        assert arg_builder.TypeConfig.class_enum.one == 11
+        assert arg_builder.TypeConfig.class_enum.two == 'ciao'
         # Optional #
         assert arg_builder.TypeOptConfig.int_p_opt_no_def is None
         assert arg_builder.TypeOptConfig.float_p_opt_no_def is None
@@ -54,6 +56,12 @@ class AllTypes:
         assert arg_builder.TypeOptConfig.tuple_p_opt_no_def_int is None
         assert arg_builder.TypeOptConfig.tuple_p_opt_no_def_str is None
         assert arg_builder.TypeOptConfig.tuple_p_opt_no_def_bool is None
+        assert arg_builder.TypeOptConfig.choice_p_opt_no_def_str is None
+        assert arg_builder.TypeOptConfig.list_choice_p_opt_no_def_str is None
+        assert arg_builder.TypeOptConfig.list_list_choice_p_opt_no_def_str is None
+        assert arg_builder.TypeOptConfig.nested_opt_no_def is None
+        assert arg_builder.TypeOptConfig.nested_list_opt_no_def is None
+        assert arg_builder.TypeOptConfig.class_enum_opt_no_def is None
 
 
 class AllDefaults:
@@ -72,6 +80,16 @@ class AllDefaults:
         assert arg_builder.TypeDefaultConfig.tuple_p_str_def == ('Spock', 'Package')
         assert arg_builder.TypeDefaultConfig.tuple_p_bool_def == (True, False)
         assert arg_builder.TypeDefaultConfig.choice_p_str_def == 'option_2'
+        assert arg_builder.TypeDefaultConfig.list_choice_p_str_def == ['option_1']
+        assert arg_builder.TypeDefaultConfig.list_list_choice_p_str_def == [['option_1'], ['option_1']]
+        assert arg_builder.TypeDefaultConfig.nested_def.one == 11
+        assert arg_builder.TypeDefaultConfig.nested_def.two == 'ciao'
+        assert arg_builder.TypeDefaultConfig.nested_list_def[0].one == 10
+        assert arg_builder.TypeDefaultConfig.nested_list_def[0].two == 'hello'
+        assert arg_builder.TypeDefaultConfig.nested_list_def[1].one == 20
+        assert arg_builder.TypeDefaultConfig.nested_list_def[1].two == 'bye'
+        assert arg_builder.TypeDefaultConfig.class_enum_def.one == 11
+        assert arg_builder.TypeDefaultConfig.class_enum_def.two == 'ciao'
         # Optional w/ Defaults #
         assert arg_builder.TypeDefaultOptConfig.int_p_opt_def == 10
         assert arg_builder.TypeDefaultOptConfig.float_p_opt_def == 10.0
@@ -84,6 +102,17 @@ class AllDefaults:
         assert arg_builder.TypeDefaultOptConfig.tuple_p_opt_def_int == (10, 20)
         assert arg_builder.TypeDefaultOptConfig.tuple_p_opt_def_str == ('Spock', 'Package')
         assert arg_builder.TypeDefaultOptConfig.tuple_p_opt_def_bool == (True, False)
+        assert arg_builder.TypeDefaultOptConfig.choice_p_str_opt_def == 'option_2'
+        assert arg_builder.TypeDefaultOptConfig.list_choice_p_str_opt_def == ['option_1']
+        assert arg_builder.TypeDefaultOptConfig.list_list_choice_p_str_opt_def == [['option_1'], ['option_1']]
+        assert arg_builder.TypeDefaultOptConfig.nested_opt_def.one == 11
+        assert arg_builder.TypeDefaultOptConfig.nested_opt_def.two == 'ciao'
+        assert arg_builder.TypeDefaultOptConfig.nested_list_opt_def[0].one == 10
+        assert arg_builder.TypeDefaultOptConfig.nested_list_opt_def[0].two == 'hello'
+        assert arg_builder.TypeDefaultOptConfig.nested_list_opt_def[1].one == 20
+        assert arg_builder.TypeDefaultOptConfig.nested_list_opt_def[1].two == 'bye'
+        assert arg_builder.TypeDefaultOptConfig.class_enum_opt_def.one == 11
+        assert arg_builder.TypeDefaultOptConfig.class_enum_opt_def.two == 'ciao'
 
 
 class AllInherited:
@@ -110,6 +139,14 @@ class AllInherited:
         assert arg_builder.TypeInherited.list_list_choice_p_str == [['option_1'], ['option_1']]
         assert arg_builder.TypeInherited.list_choice_p_int == [10]
         assert arg_builder.TypeInherited.list_choice_p_float == [10.0]
+        assert arg_builder.TypeInherited.nested.one == 11
+        assert arg_builder.TypeInherited.nested.two == 'ciao'
+        assert arg_builder.TypeInherited.nested_list[0].one == 10
+        assert arg_builder.TypeInherited.nested_list[0].two == 'hello'
+        assert arg_builder.TypeInherited.nested_list[1].one == 20
+        assert arg_builder.TypeInherited.nested_list[1].two == 'bye'
+        assert arg_builder.TypeInherited.class_enum.one == 11
+        assert arg_builder.TypeInherited.class_enum.two == 'ciao'
         # Optional w/ Defaults #
         assert arg_builder.TypeInherited.int_p_opt_def == 10
         assert arg_builder.TypeInherited.float_p_opt_def == 10.0

--- a/tests/conf/json/test.json
+++ b/tests/conf/json/test.json
@@ -34,6 +34,7 @@
       "two": "bye"
     }
   ],
+  "class_enum": "NestedStuff",
   "TypeConfig": {
     "float_p": 12.0
   }

--- a/tests/conf/toml/test.toml
+++ b/tests/conf/toml/test.toml
@@ -45,6 +45,8 @@ NestedStuff = {one = 11, two = 'ciao'}
 # Nested List configuration
 nested_list = 'NestedListStuff'
 NestedListStuff = [{one = 10, two = 'hello'}, {one = 20, two = 'bye'}]
+# Class Enum
+class_enum = 'NestedStuff'
 # Overrride general definition
 [TypeConfig]
     float_p = 12.0

--- a/tests/conf/yaml/inherited.yaml
+++ b/tests/conf/yaml/inherited.yaml
@@ -52,3 +52,5 @@ NestedListStuff:
       two: hello
     - one: 20
       two: bye
+# Class Enum
+class_enum: NestedStuff

--- a/tests/conf/yaml/test.yaml
+++ b/tests/conf/yaml/test.yaml
@@ -52,6 +52,8 @@ NestedListStuff:
       two: hello
     - one: 20
       two: bye
+# Class Enum
+class_enum: NestedStuff
 # Override general definition
 TypeConfig:
     float_p: 12.0

--- a/tests/debug/debug.py
+++ b/tests/debug/debug.py
@@ -29,6 +29,12 @@ class Stuff:
     two: str
 
 
+class ClassStuff(Enum):
+    other_stuff = OtherStuff
+    stuff = Stuff
+
+
+
 @spock
 class Test:
     # new_choice: Choice
@@ -36,11 +42,12 @@ class Test:
     # new: int
     # # fail: bool
     # # fail: List
-    test: List[int]
-    fail: List[List[int]]
-    # borken: Stuff
-    borken: List[Stuff]
-    more_borken: OtherStuff
+    # test: List[int]
+    # fail: List[List[int]]
+    # # borken: Stuff
+    # borken: List[Stuff]
+    # more_borken: OtherStuff
+    most_broken: ClassStuff
     # borken: int
     # borken: Optional[List[List[Choice]]] = [['pear'], ['banana']]
     # save_path: SavePath = '/tmp'

--- a/tests/debug/debug.py
+++ b/tests/debug/debug.py
@@ -17,6 +17,11 @@ class Choice(Enum):
     banana = 'banana'
 
 
+class IntChoice(Enum):
+    option_1 = 10
+    option_2 = 20
+
+
 @spock
 class OtherStuff:
     three: int
@@ -37,17 +42,17 @@ class ClassStuff(Enum):
 
 @spock
 class Test:
-    # new_choice: Choice
+    # new_choice: Optional[Choice]
     # # fix_me: Tuple[Tuple[int]]
-    # new: int
-    # # fail: bool
-    # # fail: List
-    # test: List[int]
-    # fail: List[List[int]]
-    # # borken: Stuff
-    # borken: List[Stuff]
+    # new: int = 3
+    # fail: bool
+    # fail: List
+    # test: List[int] = [1, 2]
+    # fail: List[List[int]] = [[1, 2], [1, 2]]
+    # borken: Stuff = Stuff
+    # borken: List[Stuff] = Stuff
     # more_borken: OtherStuff
-    most_broken: ClassStuff
+    most_broken: ClassStuff = Stuff
     # borken: int
     # borken: Optional[List[List[Choice]]] = [['pear'], ['banana']]
     # save_path: SavePath = '/tmp'

--- a/tests/debug/debug.yaml
+++ b/tests/debug/debug.yaml
@@ -15,18 +15,18 @@ Stuff:
 #    two: hello
 #  - one: 20
 #    two: bye
-#
+
 #more_borken: OtherStuff
 OtherStuff:
   three: 20
   four: ciao
-##Test2:
+###Test2:
 ###    other: 12
 ###Test:
 ###    new: 12
 ###fail: false
 ###ccccombo_breaker: 10
-##new: 1
+#new: 10
 ##other: 1
 ##Test2:
 ##  fail: 2
@@ -34,7 +34,7 @@ OtherStuff:
 ###fail: 1
 #test: [1, 2]
 
-most_broken: OtherStuff
+#most_broken: OtherStuff
 
 #save_path: /tmp
 #new_choice: pear
@@ -45,4 +45,4 @@ most_broken: OtherStuff
 #    other: 12
 #ccccombo_breaker: 10
 #new: 1
-#fail: 1
+#fail: true

--- a/tests/debug/debug.yaml
+++ b/tests/debug/debug.yaml
@@ -1,38 +1,41 @@
 #other: 1
 #new_other: 1
 #config: [debug_inherit.yaml]
-fail: [[1, 2], [2, 1]]
-##value: [1, 2]
-##fix_me: [[1, 2], [2, 1]]
-##Test:
-##    fix_me: [[11, 2], [22, 1]]
-#new_choice: pear
-borken: Stuff
+#fail: [[1, 2], [2, 1]]
+###value: [1, 2]
+###fix_me: [[1, 2], [2, 1]]
+###Test:
+###    fix_me: [[11, 2], [22, 1]]
+##new_choice: pear
+#borken: Stuff
 Stuff:
-#  one: 10
-#  two: hello
-  - one: 10
-    two: hello
-  - one: 20
-    two: bye
-
-more_borken: OtherStuff
+  one: 10
+  two: hello
+#  - one: 10
+#    two: hello
+#  - one: 20
+#    two: bye
+#
+#more_borken: OtherStuff
 OtherStuff:
   three: 20
   four: ciao
-#Test2:
-##    other: 12
-##Test:
-##    new: 12
-##fail: false
-##ccccombo_breaker: 10
-#new: 1
-#other: 1
-#Test2:
-#  fail: 2
-#  other: 3
-##fail: 1
-test: [1, 2]
+##Test2:
+###    other: 12
+###Test:
+###    new: 12
+###fail: false
+###ccccombo_breaker: 10
+##new: 1
+##other: 1
+##Test2:
+##  fail: 2
+##  other: 3
+###fail: 1
+#test: [1, 2]
+
+most_broken: OtherStuff
+
 #save_path: /tmp
 #new_choice: pear
 #borken: [[pear], [pear, banana]]


### PR DESCRIPTION
Resolves #28 

allows for enums to be of class types by overriding the attr in_ validator to check for type of the instance instead of the type of the values.

Signed-off-by: Nicholas Cilfone <nicholas.cilfone@fmr.com>