### PR TITLE
Config Print Fix

### DIFF
--- a/spock/backend/base.py
+++ b/spock/backend/base.py
@@ -31,6 +31,8 @@ class Spockspace(argparse.Namespace):
         super(Spockspace, self).__init__(**kwargs)
 
     def __repr__(self):
+        # Remove aliases in YAML dump
+        yaml.Dumper.ignore_aliases = lambda *args: True
         return yaml.dump(self.__dict__, default_flow_style=False)
 
 

--- a/spock/handlers.py
+++ b/spock/handlers.py
@@ -97,6 +97,8 @@ class YAMLHandler(Handler):
         *Returns*:
 
         """
+        # Remove aliases in YAML dump
+        yaml.Dumper.ignore_aliases = lambda *args: True
         yaml.dump(out_dict, path, default_flow_style=False)
 
 


### PR DESCRIPTION
removed aliases in YAML dump which prevented the overloaded __repr__ class from printing pretty. Same change to the YAML save handler on file write

Signed-off-by: Nicholas Cilfone <nicholas.cilfone@fmr.com>