### PR TITLE
Tuple length support

### DIFF
--- a/spock/backend/attr/utils.py
+++ b/spock/backend/attr/utils.py
@@ -135,6 +135,10 @@ def _recursive_list_to_tuple(value, typed, class_names):
     # from a composed payload
     if hasattr(typed, '__args__') and not isinstance(value, tuple) and not (isinstance(value, str)
                                                                             and value in class_names):
+        # Force those with origin tuple types to be of the defined length
+        if (typed.__origin__.__name__.lower() == 'tuple') and len(value) != len(typed.__args__):
+            raise ValueError(f'Tuple(s) use a fixed/defined length -- Length of the provided argument ({len(value)}) '
+                             f'does not match the length of the defined argument ({len(typed.__args__)})')
         # need to recurse before casting as we can't set values in a tuple with idx
         # Since it's generic it should be iterable to recurse and check it's children
         for idx, val in enumerate(value):

--- a/spock/backend/base.py
+++ b/spock/backend/base.py
@@ -70,7 +70,7 @@ class BaseSaver(ABC):  # pylint: disable=too-few-public-methods
 
         """
         supported_extensions = list(self._writers.keys())
-        if file_extension not in list(self._writers.keys()):
+        if file_extension not in self._writers:
             raise ValueError(f'Invalid fileout extension. Expected a fileout from {supported_extensions}')
         # Make the filename
         name = str(uuid1()) + '.spock.cfg' + file_extension
@@ -411,7 +411,7 @@ class BaseBuilder(ABC):  # pylint: disable=too-few-public-methods
 
         """
         protected_names = ['config', 'help']
-        if any([val in all_attr.keys() for val in protected_names]):
+        if any([val in all_attr for val in protected_names]):
             raise ValueError(f"Using a protected name from {protected_names} at general class level which prevents "
                              f"command line overrides")
 

--- a/spock/utils.py
+++ b/spock/utils.py
@@ -214,7 +214,7 @@ def check_payload_overwrite(payload, updates, configs, overwrite=''):
             current_payload = {} if payload.get(k) is None else payload.get(k)
             check_payload_overwrite(current_payload, v, configs, overwrite=overwrite)
         else:
-            if k in payload.keys():
+            if k in payload:
                 warn(f'Overriding an already set parameter {overwrite + k} from {configs}\n'
                      f'Be aware that value precedence is set by the order of the config files (last to load)...',
                      SyntaxWarning)

--- a/tests/attr/attr_configs_test.py
+++ b/tests/attr/attr_configs_test.py
@@ -76,13 +76,13 @@ class TypeConfig:
     # Required List -- Bool
     list_p_bool: List[bool]
     # Required Tuple -- Float
-    tuple_p_float: Tuple[float]
+    tuple_p_float: Tuple[float, float]
     # Required Tuple -- Int
-    tuple_p_int: Tuple[int]
+    tuple_p_int: Tuple[int, int]
     # Required Tuple -- Str
-    tuple_p_str: Tuple[str]
+    tuple_p_str: Tuple[str, str]
     # Required Tuple -- Bool
-    tuple_p_bool: Tuple[bool]
+    tuple_p_bool: Tuple[bool, bool]
     # Required choice -- Str
     choice_p_str: StrChoice
     # Required choice -- Int
@@ -124,13 +124,13 @@ class TypeOptConfig:
     # Optional List default not set
     list_p_opt_no_def_bool: Optional[List[bool]]
     # Optional Tuple default not set
-    tuple_p_opt_no_def_float: Optional[Tuple[float]]
+    tuple_p_opt_no_def_float: Optional[Tuple[float, float]]
     # Optional Tuple default not set
-    tuple_p_opt_no_def_int: Optional[Tuple[int]]
+    tuple_p_opt_no_def_int: Optional[Tuple[int, int]]
     # Optional Tuple default not set
-    tuple_p_opt_no_def_str: Optional[Tuple[str]]
+    tuple_p_opt_no_def_str: Optional[Tuple[str, str]]
     # Optional Tuple default not set
-    tuple_p_opt_no_def_bool: Optional[Tuple[bool]]
+    tuple_p_opt_no_def_bool: Optional[Tuple[bool, bool]]
     # Required choice -- Str
     choice_p_opt_no_def_str: Optional[StrChoice]
     # Required list of choice -- Str

--- a/tests/attr/test_all_attr.py
+++ b/tests/attr/test_all_attr.py
@@ -324,6 +324,16 @@ class TestChoiceRaises:
                 ConfigArgBuilder(ChoiceFail, desc='Test Builder')
 
 
+class TestTupleRaises:
+    """Check that Tuple lengths are being enforced correctly"""
+    def test_tuple_raise(self, monkeypatch):
+        with monkeypatch.context() as m:
+            m.setattr(sys, 'argv', ['', '--config',
+                                    './tests/conf/yaml/tuple.yaml'])
+            with pytest.raises(ValueError):
+                ConfigArgBuilder(TypeConfig, desc='Test Builder')
+
+
 class TestOverrideRaise:
     """Checks that override of a specific class variable is failing gracefully"""
     def test_override_raise(self, monkeypatch):

--- a/tests/conf/yaml/tuple.yaml
+++ b/tests/conf/yaml/tuple.yaml
@@ -1,0 +1,5 @@
+# include another file
+config: [test.yaml]
+# Override with incorrect tuple length
+# Required Tuple -- Int
+tuple_p_int: [10]

--- a/tests/debug/debug.py
+++ b/tests/debug/debug.py
@@ -46,7 +46,7 @@ class Test:
     # # fix_me: Tuple[Tuple[int]]
     # new: int = 3
     # fail: bool
-    # fail: List
+    fail: Tuple[Tuple[int, int], Tuple[int, int]]
     # test: List[int] = [1, 2]
     # fail: List[List[int]] = [[1, 2], [1, 2]]
     # borken: Stuff = Stuff

--- a/tests/debug/debug.yaml
+++ b/tests/debug/debug.yaml
@@ -24,8 +24,8 @@ OtherStuff:
 ###    other: 12
 ###Test:
 ###    new: 12
-###fail: false
-###ccccombo_breaker: 10
+fail: [[1, 2], [3, 4, 5]]
+##ccccombo_breaker: 10
 #new: 10
 ##other: 1
 ##Test2:


### PR DESCRIPTION
Force tuples to be length enforced unlike lists. This allows one to define a set length for an iterative argument.