### PR TITLE
Nested Classes -- Bug Fix

### DIFF
--- a/spock/backend/builder.py
+++ b/spock/backend/builder.py
@@ -297,7 +297,9 @@ class BaseBuilder(ABC):  # pylint: disable=too-few-public-methods
                     # This handles basics and references to other classes -- here we need to recurse to grab any nested
                     # defs since classes are passed as strings to the config but are defined via Enums (handled #139)
                     else:
-                        recurse_args = self._handle_recursive_defaults(args.get(default_name), args, class_names)
+                        recurse_args = self._handle_recursive_defaults(
+                            args.get(default_name), args, class_names
+                        )
                         default_value = self.input_classes[
                             class_names.index(default_name)
                         ](**recurse_args)
@@ -324,8 +326,12 @@ class BaseBuilder(ABC):  # pylint: disable=too-few-public-methods
             if v in class_names:
                 # Recurse only if in the all_args dict (from the config file)
                 if v in all_args:
-                    bubbled_dict = self._handle_recursive_defaults(all_args.get(v), all_args, class_names)
-                    out_dict.update({k: self.input_classes[class_names.index(v)](**bubbled_dict)})
+                    bubbled_dict = self._handle_recursive_defaults(
+                        all_args.get(v), all_args, class_names
+                    )
+                    out_dict.update(
+                        {k: self.input_classes[class_names.index(v)](**bubbled_dict)}
+                    )
                 # Else fall back on default instantiation
                 else:
                     out_dict.update({k: self.input_classes[class_names.index(v)]()})
@@ -854,7 +860,9 @@ class AttrBuilder(BaseBuilder):
                     "Match error -- multiple classes with the same name definition"
                 )
             else:
-                if (args.get(self.input_classes[match_idx[0]].__name__) is None) and (check_value not in class_names):
+                if (args.get(self.input_classes[match_idx[0]].__name__) is None) and (
+                    check_value not in class_names
+                ):
                     raise ValueError(
                         f"Cannot map a definition for the referenced class "
                         f"{self.input_classes[match_idx[0]].__name__}"
@@ -865,10 +873,14 @@ class AttrBuilder(BaseBuilder):
                         self.input_classes[match_idx[0]](**val) for val in current_arg
                     ]
                 else:
-                    recurse_args = self._handle_recursive_defaults(args.get(check_value), args, class_names) if check_value in args else {}
-                    class_value = self.input_classes[
-                        match_idx[0]
-                    ](**recurse_args)
+                    recurse_args = (
+                        self._handle_recursive_defaults(
+                            args.get(check_value), args, class_names
+                        )
+                        if check_value in args
+                        else {}
+                    )
+                    class_value = self.input_classes[match_idx[0]](**recurse_args)
             return_value = class_value
         # else return the expected value
         else:

--- a/spock/backend/builder.py
+++ b/spock/backend/builder.py
@@ -266,10 +266,12 @@ class BaseBuilder(ABC):  # pylint: disable=too-few-public-methods
         ]
         for val in names:
             if val not in field_list:
+                # Gets the name of the class to default to
                 default_type_name = type(
                     getattr(input_class.__attrs_attrs__, val).default
                 ).__name__
                 if default_type_name not in exclude_list:
+                    # Gets the default class object
                     default_attr = getattr(input_class.__attrs_attrs__, val).default
                     # If the default is given for a class then it's the actual class and not a type -- logic needs
                     # to deal with both
@@ -277,9 +279,14 @@ class BaseBuilder(ABC):  # pylint: disable=too-few-public-methods
                         default_name = default_attr.__name__
                     else:
                         default_name = type(default_attr).__name__
+                # Skip if in the exclude list
                 else:
                     default_name = None
+                # if we need to fall back onto the default and ff it's in the arg_list then we have a
+                # definition coming in from the config file
                 if default_name is not None and default_name in arg_list:
+                    # This handles lists of class type repeats -- these cannot be nested as the logic would be too
+                    # confusing to map to
                     if isinstance(args.get(default_name), list):
                         default_value = [
                             self.input_classes[class_names.index(default_name)](
@@ -287,12 +294,44 @@ class BaseBuilder(ABC):  # pylint: disable=too-few-public-methods
                             )
                             for arg_val in args.get(default_name)
                         ]
+                    # This handles basics and references to other classes -- here we need to recurse to grab any nested
+                    # defs since classes are passed as strings to the config but are defined via Enums (handled #139)
                     else:
+                        recurse_args = self._handle_recursive_defaults(args.get(default_name), args, class_names)
                         default_value = self.input_classes[
                             class_names.index(default_name)
-                        ](**args.get(default_name))
+                        ](**recurse_args)
                     fields.update({val: default_value})
         return fields
+
+    def _handle_recursive_defaults(self, curr_arg, all_args, class_names):
+        """Recurses through the args from the config read to determine if it can map to a definition
+
+        *Args*:
+
+            curr_arg: current argument
+            all_args: all argument dictionary
+            class_names: list of class names
+
+        *Returns*:
+
+            out_dict: recursively mapped dictionary of attributes
+
+        """
+        out_dict = {}
+        for k, v in curr_arg.items():
+            # If the value is a reference to another class we need to recurse
+            if v in class_names:
+                # Recurse only if in the all_args dict (from the config file)
+                if v in all_args:
+                    bubbled_dict = self._handle_recursive_defaults(all_args.get(v), all_args, class_names)
+                    out_dict.update({k: self.input_classes[class_names.index(v)](**bubbled_dict)})
+                # Else fall back on default instantiation
+                else:
+                    out_dict.update({k: self.input_classes[class_names.index(v)]()})
+            else:
+                out_dict.update({k: v})
+        return out_dict
 
     def build_override_parsers(self, parser):
         """Creates parsers for command-line overrides
@@ -815,18 +854,21 @@ class AttrBuilder(BaseBuilder):
                     "Match error -- multiple classes with the same name definition"
                 )
             else:
-                if args.get(self.input_classes[match_idx[0]].__name__) is None:
+                if (args.get(self.input_classes[match_idx[0]].__name__) is None) and (check_value not in class_names):
                     raise ValueError(
-                        f"Missing config file definition for the referenced class "
+                        f"Cannot map a definition for the referenced class "
                         f"{self.input_classes[match_idx[0]].__name__}"
                     )
-                current_arg = args.get(self.input_classes[match_idx[0]].__name__)
+                current_arg = args.get(self.input_classes[match_idx[0]].__name__, {})
                 if isinstance(current_arg, list):
                     class_value = [
                         self.input_classes[match_idx[0]](**val) for val in current_arg
                     ]
                 else:
-                    class_value = self.input_classes[match_idx[0]](**current_arg)
+                    recurse_args = self._handle_recursive_defaults(args.get(check_value), args, class_names) if check_value in args else {}
+                    class_value = self.input_classes[
+                        match_idx[0]
+                    ](**recurse_args)
             return_value = class_value
         # else return the expected value
         else:

--- a/spock/backend/payload.py
+++ b/spock/backend/payload.py
@@ -108,6 +108,7 @@ class BasePayload(BaseHandler):  # pylint: disable=too-few-public-methods
             base_payload = self._supported_extensions.get(config_extension)().load(
                 path, s3_config=self._s3_config
             )
+            base_payload = {} if base_payload is None else base_payload
             # Check and? update the dependencies
             deps = self._handle_dependencies(deps, path, root)
             if "config" in base_payload:

--- a/tests/base/attr_configs_test.py
+++ b/tests/base/attr_configs_test.py
@@ -56,6 +56,37 @@ class ChoiceFail:
 
 
 @spock
+class BaseDoubleNestedConfig:
+    morph_kernels_thickness: int = 1
+
+
+@spock
+class FirstDoubleNestedConfig(BaseDoubleNestedConfig):
+    h_factor: float = 0.95
+    v_factor: float = 0.95
+
+
+@spock
+class SecondDoubleNestedConfig(BaseDoubleNestedConfig):
+    morph_tolerance: float = 0.1
+
+
+class DoubleNestedEnum(Enum):
+    first = FirstDoubleNestedConfig
+    second = SecondDoubleNestedConfig
+
+
+@spock
+class SingleNestedConfig:
+    """Configuration for image based ops
+
+    Attributes:
+        kernel_config: MorphKernelConfig object
+    """
+    double_nested_config: DoubleNestedEnum = SecondDoubleNestedConfig()
+
+
+@spock
 class TypeConfig:
     """This creates a test Spock config of all supported variable types as required parameters"""
 
@@ -111,6 +142,8 @@ class TypeConfig:
     nested_list: List[NestedListStuff]
     # Class Enum
     class_enum: ClassChoice
+    # Double Nested class ref
+    high_config: SingleNestedConfig
 
 
 @spock
@@ -206,6 +239,8 @@ class TypeDefaultConfig:
     nested_list_def: List[NestedListStuff] = NestedListStuff
     # Class Enum
     class_enum_def: ClassChoice = NestedStuff
+    # Double Nested class ref
+    high_config_def: SingleNestedConfig = SingleNestedConfig()
 
 
 @spock

--- a/tests/base/base_asserts_test.py
+++ b/tests/base/base_asserts_test.py
@@ -2,7 +2,7 @@
 
 # Copyright FMR LLC <opensource@fidelity.com>
 # SPDX-License-Identifier: Apache-2.0
-
+from tests.base.attr_configs_test import FirstDoubleNestedConfig, SecondDoubleNestedConfig
 
 class AllTypes:
     # Required #
@@ -41,6 +41,10 @@ class AllTypes:
         assert arg_builder.TypeConfig.nested_list[1].two == "bye"
         assert arg_builder.TypeConfig.class_enum.one == 11
         assert arg_builder.TypeConfig.class_enum.two == "ciao"
+        assert isinstance(arg_builder.TypeConfig.high_config.double_nested_config, FirstDoubleNestedConfig) is True
+        assert arg_builder.TypeConfig.high_config.double_nested_config.h_factor == 0.99
+        assert arg_builder.TypeConfig.high_config.double_nested_config.v_factor == 0.90
+
         # Optional #
         assert arg_builder.TypeOptConfig.int_p_opt_no_def is None
         assert arg_builder.TypeOptConfig.float_p_opt_no_def is None
@@ -92,6 +96,11 @@ class AllDefaults:
         assert arg_builder.TypeDefaultConfig.nested_list_def[1].two == "bye"
         assert arg_builder.TypeDefaultConfig.class_enum_def.one == 11
         assert arg_builder.TypeDefaultConfig.class_enum_def.two == "ciao"
+        assert isinstance(arg_builder.TypeDefaultConfig.high_config_def.double_nested_config,
+                          FirstDoubleNestedConfig) is True
+        assert arg_builder.TypeDefaultConfig.high_config_def.double_nested_config.h_factor == 0.99
+        assert arg_builder.TypeDefaultConfig.high_config_def.double_nested_config.v_factor == 0.90
+
         # Optional w/ Defaults #
         assert arg_builder.TypeDefaultOptConfig.int_p_opt_def == 10
         assert arg_builder.TypeDefaultOptConfig.float_p_opt_def == 10.0
@@ -163,6 +172,11 @@ class AllInherited:
         assert arg_builder.TypeInherited.nested_list[1].two == "bye"
         assert arg_builder.TypeInherited.class_enum.one == 11
         assert arg_builder.TypeInherited.class_enum.two == "ciao"
+        assert isinstance(arg_builder.TypeInherited.high_config.double_nested_config,
+                          FirstDoubleNestedConfig) is True
+        assert arg_builder.TypeInherited.high_config.double_nested_config.h_factor == 0.99
+        assert arg_builder.TypeInherited.high_config.double_nested_config.v_factor == 0.90
+
         # Optional w/ Defaults #
         assert arg_builder.TypeInherited.int_p_opt_def == 10
         assert arg_builder.TypeInherited.float_p_opt_def == 10.0

--- a/tests/base/test_cmd_line.py
+++ b/tests/base/test_cmd_line.py
@@ -72,10 +72,17 @@ class TestClassCmdLineOverride:
                     "[11, 21]",
                     "--TypeConfig.nested_list.NestedListStuff.two",
                     "['Hooray', 'Working']",
+                    "--TypeConfig.high_config",
+                    "SingleNestedConfig",
+                    "--SingleNestedConfig.double_nested_config",
+                    "SecondDoubleNestedConfig",
+                    "--SecondDoubleNestedConfig.morph_tolerance",
+                    "0.2"
                 ],
             )
             config = ConfigArgBuilder(
-                TypeConfig, NestedStuff, NestedListStuff, desc="Test Builder"
+                TypeConfig, NestedStuff, NestedListStuff, SingleNestedConfig,
+                FirstDoubleNestedConfig, SecondDoubleNestedConfig,desc="Test Builder"
             )
             return config.generate()
 
@@ -110,6 +117,8 @@ class TestClassCmdLineOverride:
         assert arg_builder.NestedListStuff[0].two == "Hooray"
         assert arg_builder.NestedListStuff[1].one == 21
         assert arg_builder.NestedListStuff[1].two == "Working"
+        assert isinstance(arg_builder.SingleNestedConfig.double_nested_config, SecondDoubleNestedConfig) is True
+        assert arg_builder.SecondDoubleNestedConfig.morph_tolerance == 0.2
 
 
 class TestClassOnlyCmdLine:
@@ -177,10 +186,13 @@ class TestClassOnlyCmdLine:
                     "[11, 21]",
                     "--TypeConfig.nested_list.NestedListStuff.two",
                     "['Hooray', 'Working']",
+                    "--TypeConfig.high_config",
+                    "SingleNestedConfig"
                 ],
             )
             config = ConfigArgBuilder(
-                TypeConfig, NestedStuff, NestedListStuff, desc="Test Builder"
+                TypeConfig, NestedStuff, NestedListStuff, SingleNestedConfig,
+                FirstDoubleNestedConfig, SecondDoubleNestedConfig, desc="Test Builder"
             )
             return config.generate()
 
@@ -211,6 +223,10 @@ class TestClassOnlyCmdLine:
         assert arg_builder.TypeConfig.list_choice_p_float == [20.0]
         assert arg_builder.TypeConfig.class_enum.one == 12
         assert arg_builder.TypeConfig.class_enum.two == "ancora"
+        assert isinstance(arg_builder.TypeConfig.high_config.double_nested_config,
+                          SecondDoubleNestedConfig) is True
+        assert arg_builder.TypeConfig.high_config.double_nested_config.morph_kernels_thickness == 1
+        assert arg_builder.TypeConfig.high_config.double_nested_config.morph_tolerance == 0.1
         assert arg_builder.NestedListStuff[0].one == 11
         assert arg_builder.NestedListStuff[0].two == "Hooray"
         assert arg_builder.NestedListStuff[1].one == 21
@@ -235,7 +251,8 @@ class TestRaiseCmdLineNoKey:
             )
             with pytest.raises(SystemExit):
                 config = ConfigArgBuilder(
-                    TypeConfig, NestedStuff, NestedListStuff, desc="Test Builder"
+                    TypeConfig, NestedStuff, NestedListStuff, SingleNestedConfig,
+                    FirstDoubleNestedConfig, SecondDoubleNestedConfig, desc="Test Builder"
                 )
                 return config.generate()
 
@@ -258,6 +275,7 @@ class TestRaiseCmdLineListLen:
             )
             with pytest.raises(ValueError):
                 config = ConfigArgBuilder(
-                    TypeConfig, NestedStuff, NestedListStuff, desc="Test Builder"
+                    TypeConfig, NestedStuff, NestedListStuff, SingleNestedConfig,
+                    FirstDoubleNestedConfig, SecondDoubleNestedConfig, desc="Test Builder"
                 )
                 return config.generate()

--- a/tests/base/test_config_arg_builder.py
+++ b/tests/base/test_config_arg_builder.py
@@ -17,7 +17,8 @@ class TestBasic(AllTypes):
         with monkeypatch.context() as m:
             m.setattr(sys, "argv", ["", "--config", "./tests/conf/yaml/test.yaml"])
             config = ConfigArgBuilder(
-                TypeConfig, NestedStuff, NestedListStuff, TypeOptConfig
+                TypeConfig, NestedStuff, NestedListStuff, TypeOptConfig, SingleNestedConfig,
+                FirstDoubleNestedConfig, SecondDoubleNestedConfig
             )
             return config.generate()
 
@@ -27,7 +28,8 @@ class TestConfigDict:
         with monkeypatch.context() as m:
             m.setattr(sys, "argv", ["", "--config", "./tests/conf/yaml/test.yaml"])
             config_dict = ConfigArgBuilder(
-                TypeConfig, NestedStuff, NestedListStuff, TypeOptConfig
+                TypeConfig, NestedStuff, NestedListStuff, TypeOptConfig, SingleNestedConfig,
+                FirstDoubleNestedConfig, SecondDoubleNestedConfig
             ).config_2_dict
             assert isinstance(config_dict, dict) is True
 
@@ -44,6 +46,9 @@ class TestNoCmdLineKwarg(AllTypes):
                 NestedStuff,
                 NestedListStuff,
                 TypeOptConfig,
+                SingleNestedConfig,
+                FirstDoubleNestedConfig,
+                SecondDoubleNestedConfig,
                 no_cmd_line=True,
                 configs=["./tests/conf/yaml/test.yaml"],
             )
@@ -61,6 +66,9 @@ class TestNoCmdLineKwargRaise:
                     NestedStuff,
                     NestedListStuff,
                     TypeOptConfig,
+                    SingleNestedConfig,
+                    FirstDoubleNestedConfig,
+                    SecondDoubleNestedConfig,
                     no_cmd_line=True,
                     configs="./tests/conf/yaml/test.yaml",
                 )
@@ -78,6 +86,9 @@ class TestNoCmdLineRaise:
                     NestedStuff,
                     NestedListStuff,
                     TypeOptConfig,
+                    SingleNestedConfig,
+                    FirstDoubleNestedConfig,
+                    SecondDoubleNestedConfig,
                     no_cmd_line=True,
                 )
 
@@ -95,6 +106,9 @@ class TestConfigKwarg(AllTypes):
                 NestedStuff,
                 NestedListStuff,
                 TypeOptConfig,
+                SingleNestedConfig,
+                FirstDoubleNestedConfig,
+                SecondDoubleNestedConfig,
                 desc="Test Builder",
                 configs=["./tests/conf/yaml/test.yaml"],
             )
@@ -124,6 +138,9 @@ class TestNonAttrs:
                     NestedStuff,
                     NestedListStuff,
                     TypeOptConfig,
+                    SingleNestedConfig,
+                    FirstDoubleNestedConfig,
+                    SecondDoubleNestedConfig,
                     AttrFail,
                     configs=["./tests/conf/yaml/test.yaml"],
                 )
@@ -142,6 +159,9 @@ class TestRaiseWrongInputType:
                     NestedStuff,
                     NestedListStuff,
                     TypeOptConfig,
+                    SingleNestedConfig,
+                    FirstDoubleNestedConfig,
+                    SecondDoubleNestedConfig,
                     desc="Test Builder",
                 )
                 return config.generate()
@@ -155,7 +175,8 @@ class TestUnknownArg:
             )
             with pytest.raises(ValueError):
                 ConfigArgBuilder(
-                    TypeConfig, NestedStuff, NestedListStuff, desc="Test Builder"
+                    TypeConfig, NestedStuff, NestedListStuff, SingleNestedConfig,
+                    FirstDoubleNestedConfig, SecondDoubleNestedConfig, desc="Test Builder"
                 )
 
 
@@ -169,7 +190,8 @@ class TestUnknownClassParameterArg:
             )
             with pytest.raises(ValueError):
                 ConfigArgBuilder(
-                    TypeConfig, NestedStuff, NestedListStuff, desc="Test Builder"
+                    TypeConfig, NestedStuff, NestedListStuff, SingleNestedConfig,
+                    FirstDoubleNestedConfig, SecondDoubleNestedConfig, desc="Test Builder"
                 )
 
 
@@ -183,7 +205,8 @@ class TestUnknownClassArg:
             )
             with pytest.raises(ValueError):
                 ConfigArgBuilder(
-                    TypeConfig, NestedStuff, NestedListStuff, desc="Test Builder"
+                    TypeConfig, NestedStuff, NestedListStuff, SingleNestedConfig,
+                    FirstDoubleNestedConfig, SecondDoubleNestedConfig, desc="Test Builder"
                 )
 
 
@@ -201,5 +224,6 @@ class TestWrongRepeatedClass:
             )
             with pytest.raises(ValueError):
                 ConfigArgBuilder(
-                    TypeConfig, NestedStuff, NestedListStuff, desc="Test Builder"
+                    TypeConfig, NestedStuff, NestedListStuff, SingleNestedConfig,
+                    FirstDoubleNestedConfig, SecondDoubleNestedConfig, desc="Test Builder"
                 )

--- a/tests/base/test_loaders.py
+++ b/tests/base/test_loaders.py
@@ -22,6 +22,9 @@ class TestAllTypesYAML(AllTypes):
                 NestedStuff,
                 NestedListStuff,
                 TypeOptConfig,
+                SingleNestedConfig,
+                FirstDoubleNestedConfig,
+                SecondDoubleNestedConfig,
                 desc="Test Builder",
             )
             return config.generate()
@@ -40,9 +43,11 @@ class TestAllDefaultsYAML(AllDefaults):
                 NestedStuff,
                 NestedListStuff,
                 NestedStuffDefault,
-                TypeOptConfig,
                 TypeDefaultConfig,
                 TypeDefaultOptConfig,
+                SingleNestedConfig,
+                FirstDoubleNestedConfig,
+                SecondDoubleNestedConfig,
                 desc="Test Builder",
             )
             return config.generate()
@@ -57,7 +62,8 @@ class TestInheritance(AllInherited):
         with monkeypatch.context() as m:
             m.setattr(sys, "argv", ["", "--config", "./tests/conf/yaml/inherited.yaml"])
             config = ConfigArgBuilder(
-                TypeInherited, NestedStuff, NestedListStuff, desc="Test Builder"
+                TypeInherited, NestedStuff, NestedListStuff, SingleNestedConfig,
+                FirstDoubleNestedConfig, SecondDoubleNestedConfig, desc="Test Builder"
             )
             return config.generate()
 
@@ -76,6 +82,9 @@ class TestAllTypesTOML(AllTypes):
                 NestedStuff,
                 NestedListStuff,
                 TypeOptConfig,
+                SingleNestedConfig,
+                FirstDoubleNestedConfig,
+                SecondDoubleNestedConfig,
                 desc="Test Builder",
             )
             return config.generate()
@@ -97,6 +106,9 @@ class TestAllDefaultsTOML(AllDefaults):
                 TypeOptConfig,
                 TypeDefaultConfig,
                 TypeDefaultOptConfig,
+                SingleNestedConfig,
+                FirstDoubleNestedConfig,
+                SecondDoubleNestedConfig,
                 desc="Test Builder",
             )
             return config.generate()
@@ -116,6 +128,9 @@ class TestAllTypesJSON(AllTypes):
                 NestedStuff,
                 NestedListStuff,
                 TypeOptConfig,
+                SingleNestedConfig,
+                FirstDoubleNestedConfig,
+                SecondDoubleNestedConfig,
                 desc="Test Builder",
             )
             return config.generate()
@@ -137,6 +152,9 @@ class TestAllDefaultsJSON(AllDefaults):
                 TypeOptConfig,
                 TypeDefaultConfig,
                 TypeDefaultOptConfig,
+                SingleNestedConfig,
+                FirstDoubleNestedConfig,
+                SecondDoubleNestedConfig,
                 desc="Test Builder",
             )
             return config.generate()
@@ -157,6 +175,9 @@ class TestComposition:
                 NestedStuff,
                 NestedListStuff,
                 TypeOptConfig,
+                SingleNestedConfig,
+                FirstDoubleNestedConfig,
+                SecondDoubleNestedConfig,
                 desc="Test Builder",
             )
             return config.generate()
@@ -175,7 +196,8 @@ class TestConfigCycles:
             )
             with pytest.raises(ValueError):
                 ConfigArgBuilder(
-                    TypeConfig, NestedStuff, NestedListStuff, desc="Test Builder"
+                    TypeConfig, NestedStuff, NestedListStuff, SingleNestedConfig,
+                    FirstDoubleNestedConfig, SecondDoubleNestedConfig, desc="Test Builder"
                 )
 
 
@@ -191,7 +213,8 @@ class TestConfigIncludeRaise:
             )
             with pytest.raises(ValueError):
                 ConfigArgBuilder(
-                    TypeConfig, NestedStuff, NestedListStuff, desc="Test Builder"
+                    TypeConfig, NestedStuff, NestedListStuff, SingleNestedConfig,
+                    FirstDoubleNestedConfig, SecondDoubleNestedConfig, desc="Test Builder"
                 )
 
 
@@ -212,5 +235,6 @@ class TestConfigDuplicate:
             )
             with pytest.raises(ValueError):
                 ConfigArgBuilder(
-                    TypeConfig, NestedStuff, NestedListStuff, desc="Test Builder"
+                    TypeConfig, NestedStuff, NestedListStuff, SingleNestedConfig,
+                    FirstDoubleNestedConfig, SecondDoubleNestedConfig, desc="Test Builder"
                 )

--- a/tests/base/test_spockspace.py
+++ b/tests/base/test_spockspace.py
@@ -34,6 +34,9 @@ class TestSpockspaceRepr:
                 NestedStuff,
                 NestedListStuff,
                 TypeOptConfig,
+                SingleNestedConfig,
+                FirstDoubleNestedConfig,
+                SecondDoubleNestedConfig,
                 desc="Test Builder",
             )
             print(config.generate())
@@ -54,6 +57,9 @@ class TestFrozen:
                 NestedStuff,
                 NestedListStuff,
                 TypeOptConfig,
+                SingleNestedConfig,
+                FirstDoubleNestedConfig,
+                SecondDoubleNestedConfig,
                 desc="Test Builder",
             )
             return config.generate()

--- a/tests/base/test_type_specific.py
+++ b/tests/base/test_type_specific.py
@@ -71,12 +71,3 @@ class TestEnumClassMissing:
                 ConfigArgBuilder(
                     TypeConfig, NestedStuff, NestedListStuff, desc="Test Builder"
                 )
-
-
-# class TestMixedGeneric:
-#     def test_mixed_generic(self, monkeypatch):
-#         with monkeypatch.context() as m:
-#             with pytest.raises(TypeError):
-#                 @spock
-#                 class GenericFail:
-#                     generic_fail: Tuple[List[int], List[int], int]

--- a/tests/base/test_writers.py
+++ b/tests/base/test_writers.py
@@ -21,6 +21,9 @@ class TestDefaultWriter:
                 NestedStuff,
                 NestedListStuff,
                 TypeOptConfig,
+                SingleNestedConfig,
+                FirstDoubleNestedConfig,
+                SecondDoubleNestedConfig,
                 desc="Test Builder",
             )
             # Test the chained version
@@ -38,6 +41,9 @@ class TestYAMLWriter:
                 NestedStuff,
                 NestedListStuff,
                 TypeOptConfig,
+                SingleNestedConfig,
+                FirstDoubleNestedConfig,
+                SecondDoubleNestedConfig,
                 desc="Test Builder",
             )
             # Test the chained version
@@ -59,6 +65,9 @@ class TestYAMLWriterCreate:
                 NestedStuff,
                 NestedListStuff,
                 TypeOptConfig,
+                SingleNestedConfig,
+                FirstDoubleNestedConfig,
+                SecondDoubleNestedConfig,
                 desc="Test Builder",
             )
             # Test the chained version
@@ -86,6 +95,9 @@ class TestYAMLWriterSavePath:
                 NestedStuff,
                 NestedListStuff,
                 TypeOptConfig,
+                SingleNestedConfig,
+                FirstDoubleNestedConfig,
+                SecondDoubleNestedConfig,
                 desc="Test Builder",
             )
             # Test the chained version
@@ -124,6 +136,9 @@ class TestYAMLWriterNoPath:
                     NestedStuff,
                     NestedListStuff,
                     TypeOptConfig,
+                    SingleNestedConfig,
+                    FirstDoubleNestedConfig,
+                    SecondDoubleNestedConfig,
                     desc="Test Builder",
                 )
                 # Test the chained version
@@ -140,6 +155,9 @@ class TestWritePathRaise:
                 NestedStuff,
                 NestedListStuff,
                 TypeOptConfig,
+                SingleNestedConfig,
+                FirstDoubleNestedConfig,
+                SecondDoubleNestedConfig,
                 desc="Test Builder",
             )
             # Test the chained version
@@ -161,6 +179,9 @@ class TestInvalidExtensionTypeRaise:
                 NestedStuff,
                 NestedListStuff,
                 TypeOptConfig,
+                SingleNestedConfig,
+                FirstDoubleNestedConfig,
+                SecondDoubleNestedConfig,
                 desc="Test Builder",
             )
             # Test the chained version
@@ -181,6 +202,9 @@ class TestTOMLWriter:
                 NestedStuff,
                 NestedListStuff,
                 TypeOptConfig,
+                SingleNestedConfig,
+                FirstDoubleNestedConfig,
+                SecondDoubleNestedConfig,
                 desc="Test Builder",
             )
             # Test the chained version
@@ -202,6 +226,9 @@ class TestJSONWriter:
                 NestedStuff,
                 NestedListStuff,
                 TypeOptConfig,
+                SingleNestedConfig,
+                FirstDoubleNestedConfig,
+                SecondDoubleNestedConfig,
                 desc="Test Builder",
             )
             # Test the chained version

--- a/tests/conf/json/test.json
+++ b/tests/conf/json/test.json
@@ -36,6 +36,14 @@
     }
   ],
   "class_enum": "NestedStuff",
+  "high_config": "SingleNestedConfig",
+  "SingleNestedConfig": {
+    "double_nested_config": "FirstDoubleNestedConfig"
+  },
+  "FirstDoubleNestedConfig": {
+    "h_factor": 0.99,
+    "v_factor": 0.90
+  },
   "TypeConfig": {
     "float_p": 12.0
   }

--- a/tests/conf/toml/test.toml
+++ b/tests/conf/toml/test.toml
@@ -49,6 +49,12 @@ nested_list = 'NestedListStuff'
 NestedListStuff = [{one = 10, two = 'hello'}, {one = 20, two = 'bye'}]
 # Class Enum
 class_enum = 'NestedStuff'
+high_config = 'SingleNestedConfig'
+[SingleNestedConfig]
+    double_nested_config = 'FirstDoubleNestedConfig'
+[FirstDoubleNestedConfig]
+    h_factor = 0.99
+    v_factor = 0.90
 # Overrride general definition
 [TypeConfig]
     float_p = 12.0

--- a/tests/conf/yaml/inherited.yaml
+++ b/tests/conf/yaml/inherited.yaml
@@ -1,7 +1,7 @@
 # conf file for all YAML tests
 ### Required or Boolean Base Types ###
 # Boolean - Set
---bool_p_set
+bool_p_set: true
 # Required Int
 int_p: 10
 # Required Float
@@ -56,3 +56,11 @@ NestedListStuff:
       two: bye
 # Class Enum
 class_enum: NestedStuff
+# Nested classes
+high_config: SingleNestedConfig
+SingleNestedConfig:
+  double_nested_config: FirstDoubleNestedConfig
+FirstDoubleNestedConfig:
+  h_factor: 0.99
+  v_factor: 0.90
+

--- a/tests/conf/yaml/test.yaml
+++ b/tests/conf/yaml/test.yaml
@@ -56,6 +56,15 @@ NestedListStuff:
       two: bye
 # Class Enum
 class_enum: NestedStuff
+# Nested classes
+high_config: SingleNestedConfig
+SingleNestedConfig:
+  double_nested_config: FirstDoubleNestedConfig
+FirstDoubleNestedConfig:
+  h_factor: 0.99
+  v_factor: 0.90
+
+
 # Override general definition
 TypeConfig:
     float_p: 12.0

--- a/tests/conf/yaml/test_class.yaml
+++ b/tests/conf/yaml/test_class.yaml
@@ -47,6 +47,12 @@ TypeConfig:
   nested_list: NestedListStuff
   # Class Enum
   class_enum: NestedListStuff
+  high_config: SingleNestedConfig
+SingleNestedConfig:
+  double_nested_config: FirstDoubleNestedConfig
+FirstDoubleNestedConfig:
+  h_factor: 0.99
+  v_factor: 0.90
 NestedListStuff:
     - one: 10
       two: hello

--- a/tests/s3/test_io.py
+++ b/tests/s3/test_io.py
@@ -34,6 +34,9 @@ class TestAllTypesFromS3MockYAML(AllTypes):
                 NestedStuff,
                 NestedListStuff,
                 TypeOptConfig,
+                SingleNestedConfig,
+                FirstDoubleNestedConfig,
+                SecondDoubleNestedConfig,
                 s3_config=S3Config(session=aws_session, s3_session=s3_client),
                 desc="Test Builder",
             )
@@ -51,6 +54,9 @@ class TestS3MockYAMLWriter:
                 NestedStuff,
                 NestedListStuff,
                 TypeOptConfig,
+                SingleNestedConfig,
+                FirstDoubleNestedConfig,
+                SecondDoubleNestedConfig,
                 s3_config=S3Config(session=aws_session, s3_session=s3_client),
                 desc="Test Builder",
             )

--- a/tests/s3/test_raises.py
+++ b/tests/s3/test_raises.py
@@ -31,6 +31,9 @@ class TestAllTypesFromS3MockYAMLMissingS3:
                     NestedStuff,
                     NestedListStuff,
                     TypeOptConfig,
+                    SingleNestedConfig,
+                    FirstDoubleNestedConfig,
+                    SecondDoubleNestedConfig,
                     desc="Test Builder",
                 )
 
@@ -55,6 +58,9 @@ class TestAllTypesFromS3MockYAMLNoObject:
                     NestedStuff,
                     NestedListStuff,
                     TypeOptConfig,
+                    SingleNestedConfig,
+                    FirstDoubleNestedConfig,
+                    SecondDoubleNestedConfig,
                     s3_config=S3Config(session=aws_session, s3_session=s3_client),
                     desc="Test Builder",
                 )
@@ -71,6 +77,9 @@ class TestS3MockYAMLWriterMissingS3:
                 NestedStuff,
                 NestedListStuff,
                 TypeOptConfig,
+                SingleNestedConfig,
+                FirstDoubleNestedConfig,
+                SecondDoubleNestedConfig,
                 desc="Test Builder",
             )
             # Mock a S3 bucket and object
@@ -101,6 +110,9 @@ class TestS3MockYAMLWriterNoBucket:
                 NestedStuff,
                 NestedListStuff,
                 TypeOptConfig,
+                SingleNestedConfig,
+                FirstDoubleNestedConfig,
+                SecondDoubleNestedConfig,
                 desc="Test Builder",
             )
             # Mock a S3 bucket and object


### PR DESCRIPTION
fixes issues wrt more than 2 levels of class nesting references. code was assuming to fall back on defaults instead of recursing the config space to set the correct parameters.

Handles (#139)

+ extra unit tests
+ linted

