### PR TITLE
Fix missing classes in spockspace

### DIFF
--- a/spock/backend/field_handlers.py
+++ b/spock/backend/field_handlers.py
@@ -86,14 +86,22 @@ class RegisterFieldTemplate(ABC):
         # Instances might have other instances that might be defined in the configs
         # Recurse to try and catch all config defs
         # Only map if default is not None -- do so by evolving the attribute
-        if _is_spock_instance(attr_space.attribute.type) and attr_space.attribute.default is not None:
-            attr_space.field, special_keys = RegisterSpockCls().recurse_generate(attr_space.attribute.type, builder_space)
+        if (
+            _is_spock_instance(attr_space.attribute.type)
+            and attr_space.attribute.default is not None
+        ):
+            attr_space.field, special_keys = RegisterSpockCls().recurse_generate(
+                attr_space.attribute.type, builder_space
+            )
             attr_space.attribute = attr_space.attribute.evolve(default=attr_space.field)
-            builder_space.spock_space[attr_space.attribute.type.__name__] = attr_space.field
+            builder_space.spock_space[
+                attr_space.attribute.type.__name__
+            ] = attr_space.field
             self.special_keys.update(special_keys)
         return (
             attr_space.config_space.name in builder_space.arguments
-            and attr_space.attribute.name in builder_space.arguments[attr_space.config_space.name]
+            and attr_space.attribute.name
+            in builder_space.arguments[attr_space.config_space.name]
         )
 
     @staticmethod
@@ -298,7 +306,9 @@ class RegisterEnum(RegisterFieldTemplate):
         """
         super().handle_optional_attribute_value(attr_space, builder_space)
         if attr_space.field is not None:
-            builder_space.spock_space[type(attr_space.field).__name__] = attr_space.field
+            builder_space.spock_space[
+                type(attr_space.field).__name__
+            ] = attr_space.field
 
     def _handle_and_register_enum(
         self, enum_cls, attr_space: AttributeSpace, builder_space: BuilderSpace

--- a/spock/backend/field_handlers.py
+++ b/spock/backend/field_handlers.py
@@ -297,7 +297,8 @@ class RegisterEnum(RegisterFieldTemplate):
         Returns:
         """
         super().handle_optional_attribute_value(attr_space, builder_space)
-        builder_space.spock_space[type(attr_space.field).__name__] = attr_space.field
+        if attr_space.field is not None:
+            builder_space.spock_space[type(attr_space.field).__name__] = attr_space.field
 
     def _handle_and_register_enum(
         self, enum_cls, attr_space: AttributeSpace, builder_space: BuilderSpace

--- a/spock/backend/saver.py
+++ b/spock/backend/saver.py
@@ -219,6 +219,8 @@ class AttrSaver(BaseSaver):
         )
         # Convert values
         clean_dict = self._clean_output(out_dict)
+        # Clip any empty dictionaries
+        clean_dict = {k: v for k, v in clean_dict.items() if len(v) > 0}
         return clean_dict
 
     def _clean_tuner_values(self, payload):

--- a/spock/graph.py
+++ b/spock/graph.py
@@ -62,8 +62,10 @@ class Graph:
             dep_classes = self._find_all_spock_classes(input_class)
             for v in dep_classes:
                 if v not in nodes:
-                    raise ValueError(f'Missing @spock decorated class -- `{v.__name__}` was not passed as an *arg to '
-                                     f'ConfigArgBuilder')
+                    raise ValueError(
+                        f"Missing @spock decorated class -- `{v.__name__}` was not passed as an *arg to "
+                        f"ConfigArgBuilder"
+                    )
                 nodes.get(v).append(input_class)
         nodes = {key: set(val) for key, val in nodes.items()}
         return nodes

--- a/spock/graph.py
+++ b/spock/graph.py
@@ -61,6 +61,9 @@ class Graph:
         for input_class in self._input_classes:
             dep_classes = self._find_all_spock_classes(input_class)
             for v in dep_classes:
+                if v not in nodes:
+                    raise ValueError(f'Missing @spock decorated class -- `{v.__name__}` was not passed as an *arg to '
+                                     f'ConfigArgBuilder')
                 nodes.get(v).append(input_class)
         nodes = {key: set(val) for key, val in nodes.items()}
         return nodes

--- a/tests/base/attr_configs_test.py
+++ b/tests/base/attr_configs_test.py
@@ -42,6 +42,12 @@ class NestedStuff:
 
 
 @spock
+class NestedStuffOpt:
+    one: int = 1
+    two: str = 'boo'
+
+
+@spock
 class NestedListStuff:
     one: int
     two: str
@@ -186,7 +192,7 @@ class TypeOptConfig:
     # Required list of list of choice -- Str
     list_list_choice_p_opt_no_def_str: Optional[List[List[StrChoice]]]
     # Nested configuration
-    nested_opt_no_def: Optional[NestedStuff]
+    nested_opt_no_def: Optional[NestedStuffOpt]
     # Nested list configuration
     nested_list_opt_no_def: Optional[List[NestedListStuff]]
     # Class Enum
@@ -302,3 +308,15 @@ class TypeInherited(TypeConfig, TypeDefaultOptConfig):
     """This tests inheritance with mixed default and non-default arguments"""
 
     ...
+
+
+all_configs = [
+    TypeConfig,
+    NestedStuff,
+    NestedListStuff,
+    TypeOptConfig,
+    SingleNestedConfig,
+    FirstDoubleNestedConfig,
+    SecondDoubleNestedConfig,
+    NestedStuffOpt
+]

--- a/tests/base/base_asserts_test.py
+++ b/tests/base/base_asserts_test.py
@@ -1,11 +1,8 @@
 # -*- coding: utf-8 -*-
-
 # Copyright FMR LLC <opensource@fidelity.com>
 # SPDX-License-Identifier: Apache-2.0
-from tests.base.attr_configs_test import (
-    FirstDoubleNestedConfig,
-    SecondDoubleNestedConfig,
-)
+
+from tests.base.attr_configs_test import FirstDoubleNestedConfig
 
 
 class AllTypes:

--- a/tests/base/test_config_arg_builder.py
+++ b/tests/base/test_config_arg_builder.py
@@ -16,10 +16,7 @@ class TestBasic(AllTypes):
     def arg_builder(monkeypatch):
         with monkeypatch.context() as m:
             m.setattr(sys, "argv", ["", "--config", "./tests/conf/yaml/test.yaml"])
-            config = ConfigArgBuilder(
-                TypeConfig, NestedStuff, NestedListStuff, TypeOptConfig, SingleNestedConfig,
-                FirstDoubleNestedConfig, SecondDoubleNestedConfig
-            )
+            config = ConfigArgBuilder(*all_configs)
             return config.generate()
 
 
@@ -27,10 +24,7 @@ class TestConfigDict:
     def test_config_2_dict(self, monkeypatch):
         with monkeypatch.context() as m:
             m.setattr(sys, "argv", ["", "--config", "./tests/conf/yaml/test.yaml"])
-            config_dict = ConfigArgBuilder(
-                TypeConfig, NestedStuff, NestedListStuff, TypeOptConfig, SingleNestedConfig,
-                FirstDoubleNestedConfig, SecondDoubleNestedConfig
-            ).config_2_dict
+            config_dict = ConfigArgBuilder(*all_configs).config_2_dict
             assert isinstance(config_dict, dict) is True
 
 
@@ -42,13 +36,7 @@ class TestNoCmdLineKwarg(AllTypes):
     def arg_builder(monkeypatch):
         with monkeypatch.context() as m:
             config = ConfigArgBuilder(
-                TypeConfig,
-                NestedStuff,
-                NestedListStuff,
-                TypeOptConfig,
-                SingleNestedConfig,
-                FirstDoubleNestedConfig,
-                SecondDoubleNestedConfig,
+                *all_configs,
                 no_cmd_line=True,
                 configs=["./tests/conf/yaml/test.yaml"],
             )
@@ -62,13 +50,7 @@ class TestNoCmdLineKwargRaise:
         with monkeypatch.context() as m:
             with pytest.raises(TypeError):
                 config = ConfigArgBuilder(
-                    TypeConfig,
-                    NestedStuff,
-                    NestedListStuff,
-                    TypeOptConfig,
-                    SingleNestedConfig,
-                    FirstDoubleNestedConfig,
-                    SecondDoubleNestedConfig,
+                    *all_configs,
                     no_cmd_line=True,
                     configs="./tests/conf/yaml/test.yaml",
                 )
@@ -82,13 +64,7 @@ class TestNoCmdLineRaise:
         with monkeypatch.context() as m:
             with pytest.raises(ValueError):
                 ConfigArgBuilder(
-                    TypeConfig,
-                    NestedStuff,
-                    NestedListStuff,
-                    TypeOptConfig,
-                    SingleNestedConfig,
-                    FirstDoubleNestedConfig,
-                    SecondDoubleNestedConfig,
+                    *all_configs,
                     no_cmd_line=True,
                 )
 
@@ -102,13 +78,7 @@ class TestConfigKwarg(AllTypes):
         with monkeypatch.context() as m:
             m.setattr(sys, "argv", [""])
             config = ConfigArgBuilder(
-                TypeConfig,
-                NestedStuff,
-                NestedListStuff,
-                TypeOptConfig,
-                SingleNestedConfig,
-                FirstDoubleNestedConfig,
-                SecondDoubleNestedConfig,
+                *all_configs,
                 desc="Test Builder",
                 configs=["./tests/conf/yaml/test.yaml"],
             )
@@ -134,15 +104,22 @@ class TestNonAttrs:
                     failed_attr: int
 
                 config = ConfigArgBuilder(
-                    TypeConfig,
-                    NestedStuff,
-                    NestedListStuff,
-                    TypeOptConfig,
-                    SingleNestedConfig,
-                    FirstDoubleNestedConfig,
-                    SecondDoubleNestedConfig,
+                    *all_configs,
                     AttrFail,
                     configs=["./tests/conf/yaml/test.yaml"],
+                )
+                return config.generate()
+
+
+class TestRaisesMissingClass:
+    """Testing basic functionality"""
+
+    def test_raises_missing_class(self, monkeypatch):
+        with monkeypatch.context() as m:
+            m.setattr(sys, "argv", ["", "--config", "./tests/conf/yaml/test.yaml"])
+            with pytest.raises(ValueError):
+                config = ConfigArgBuilder(
+                    *all_configs[:-1]
                 )
                 return config.generate()
 
@@ -155,13 +132,7 @@ class TestRaiseWrongInputType:
             m.setattr(sys, "argv", ["", "--config", "./tests/conf/yaml/test.foo"])
             with pytest.raises(TypeError):
                 config = ConfigArgBuilder(
-                    TypeConfig,
-                    NestedStuff,
-                    NestedListStuff,
-                    TypeOptConfig,
-                    SingleNestedConfig,
-                    FirstDoubleNestedConfig,
-                    SecondDoubleNestedConfig,
+                    *all_configs,
                     desc="Test Builder",
                 )
                 return config.generate()
@@ -175,8 +146,7 @@ class TestUnknownArg:
             )
             with pytest.raises(ValueError):
                 ConfigArgBuilder(
-                    TypeConfig, NestedStuff, NestedListStuff, SingleNestedConfig,
-                    FirstDoubleNestedConfig, SecondDoubleNestedConfig, desc="Test Builder"
+                    *all_configs, desc="Test Builder"
                 )
 
 
@@ -190,8 +160,7 @@ class TestUnknownClassParameterArg:
             )
             with pytest.raises(ValueError):
                 ConfigArgBuilder(
-                    TypeConfig, NestedStuff, NestedListStuff, SingleNestedConfig,
-                    FirstDoubleNestedConfig, SecondDoubleNestedConfig, desc="Test Builder"
+                    *all_configs, desc="Test Builder"
                 )
 
 
@@ -205,8 +174,7 @@ class TestUnknownClassArg:
             )
             with pytest.raises(TypeError):
                 ConfigArgBuilder(
-                    TypeConfig, NestedStuff, NestedListStuff, SingleNestedConfig,
-                    FirstDoubleNestedConfig, SecondDoubleNestedConfig, desc="Test Builder"
+                    *all_configs, desc="Test Builder"
                 )
 
 
@@ -224,6 +192,5 @@ class TestWrongRepeatedClass:
             )
             with pytest.raises(ValueError):
                 ConfigArgBuilder(
-                    TypeConfig, NestedStuff, NestedListStuff, SingleNestedConfig,
-                    FirstDoubleNestedConfig, SecondDoubleNestedConfig, desc="Test Builder"
+                    *all_configs, desc="Test Builder"
                 )

--- a/tests/base/test_loaders.py
+++ b/tests/base/test_loaders.py
@@ -19,13 +19,7 @@ class TestAllTypesYAML(AllTypes):
         with monkeypatch.context() as m:
             m.setattr(sys, "argv", ["", "--config", "./tests/conf/yaml/test.yaml"])
             config = ConfigArgBuilder(
-                TypeConfig,
-                NestedStuff,
-                NestedListStuff,
-                TypeOptConfig,
-                SingleNestedConfig,
-                FirstDoubleNestedConfig,
-                SecondDoubleNestedConfig,
+                *all_configs,
                 desc="Test Builder",
             )
             return config.generate()
@@ -42,6 +36,7 @@ class TestAllDefaultsYAML(AllDefaults):
             config = ConfigArgBuilder(
                 TypeConfig,
                 NestedStuff,
+                NestedStuffOpt,
                 NestedListStuff,
                 NestedListStuffDef,
                 NestedStuffDefault,
@@ -64,7 +59,7 @@ class TestInheritance(AllInherited):
         with monkeypatch.context() as m:
             m.setattr(sys, "argv", ["", "--config", "./tests/conf/yaml/inherited.yaml"])
             config = ConfigArgBuilder(
-                TypeInherited, NestedStuff, NestedListStuff, SingleNestedConfig,
+                TypeInherited, NestedStuff, NestedStuffOpt, NestedListStuff, SingleNestedConfig,
                 FirstDoubleNestedConfig, SecondDoubleNestedConfig, desc="Test Builder"
             )
             return config.generate()
@@ -80,13 +75,7 @@ class TestAllTypesTOML(AllTypes):
         with monkeypatch.context() as m:
             m.setattr(sys, "argv", ["", "--config", "./tests/conf/toml/test.toml"])
             config = ConfigArgBuilder(
-                TypeConfig,
-                NestedStuff,
-                NestedListStuff,
-                TypeOptConfig,
-                SingleNestedConfig,
-                FirstDoubleNestedConfig,
-                SecondDoubleNestedConfig,
+                *all_configs,
                 desc="Test Builder",
             )
             return config.generate()
@@ -103,6 +92,7 @@ class TestAllDefaultsTOML(AllDefaults):
             config = ConfigArgBuilder(
                 TypeConfig,
                 NestedStuff,
+                NestedStuffOpt,
                 NestedListStuff,
                 NestedListStuffDef,
                 NestedStuffDefault,
@@ -127,13 +117,7 @@ class TestAllTypesJSON(AllTypes):
         with monkeypatch.context() as m:
             m.setattr(sys, "argv", ["", "--config", "./tests/conf/json/test.json"])
             config = ConfigArgBuilder(
-                TypeConfig,
-                NestedStuff,
-                NestedListStuff,
-                TypeOptConfig,
-                SingleNestedConfig,
-                FirstDoubleNestedConfig,
-                SecondDoubleNestedConfig,
+                *all_configs,
                 desc="Test Builder",
             )
             return config.generate()
@@ -151,6 +135,7 @@ class TestAllDefaultsJSON(AllDefaults):
                 TypeConfig,
                 NestedStuff,
                 NestedListStuff,
+                NestedStuffOpt,
                 NestedListStuffDef,
                 NestedStuffDefault,
                 TypeOptConfig,
@@ -175,13 +160,7 @@ class TestComposition:
                 sys, "argv", ["", "--config", "./tests/conf/yaml/test_include.yaml"]
             )
             config = ConfigArgBuilder(
-                TypeConfig,
-                NestedStuff,
-                NestedListStuff,
-                TypeOptConfig,
-                SingleNestedConfig,
-                FirstDoubleNestedConfig,
-                SecondDoubleNestedConfig,
+                *all_configs,
                 desc="Test Builder",
             )
             return config.generate()
@@ -200,8 +179,7 @@ class TestConfigCycles:
             )
             with pytest.raises(ValueError):
                 ConfigArgBuilder(
-                    TypeConfig, NestedStuff, NestedListStuff, SingleNestedConfig,
-                    FirstDoubleNestedConfig, SecondDoubleNestedConfig, desc="Test Builder"
+                    *all_configs, desc="Test Builder"
                 )
 
 
@@ -217,8 +195,7 @@ class TestConfigIncludeRaise:
             )
             with pytest.raises(FileNotFoundError):
                 ConfigArgBuilder(
-                    TypeConfig, NestedStuff, NestedListStuff, SingleNestedConfig,
-                    FirstDoubleNestedConfig, SecondDoubleNestedConfig, desc="Test Builder"
+                    *all_configs, desc="Test Builder"
                 )
 
 
@@ -239,8 +216,7 @@ class TestConfigDuplicate:
             )
             with pytest.raises(ValueError):
                 ConfigArgBuilder(
-                    TypeConfig, NestedStuff, NestedListStuff, SingleNestedConfig,
-                    FirstDoubleNestedConfig, SecondDoubleNestedConfig, desc="Test Builder"
+                    *all_configs, desc="Test Builder"
                 )
 
 

--- a/tests/base/test_spockspace.py
+++ b/tests/base/test_spockspace.py
@@ -16,13 +16,7 @@ class TestHelp:
             )
             with pytest.raises(SystemExit):
                 config = ConfigArgBuilder(
-                    TypeConfig,
-                    NestedStuff,
-                    NestedListStuff,
-                    TypeOptConfig,
-                    SingleNestedConfig,
-                    FirstDoubleNestedConfig,
-                    SecondDoubleNestedConfig,
+                    *all_configs,
                     desc="Test Builder",
                 )
                 return config.generate()
@@ -33,13 +27,7 @@ class TestSpockspaceRepr:
         with monkeypatch.context() as m:
             m.setattr(sys, "argv", ["", "--config", "./tests/conf/yaml/test.yaml"])
             config = ConfigArgBuilder(
-                TypeConfig,
-                NestedStuff,
-                NestedListStuff,
-                TypeOptConfig,
-                SingleNestedConfig,
-                FirstDoubleNestedConfig,
-                SecondDoubleNestedConfig,
+                *all_configs,
                 desc="Test Builder",
             )
             print(config.generate())
@@ -56,13 +44,7 @@ class TestFrozen:
         with monkeypatch.context() as m:
             m.setattr(sys, "argv", ["", "--config", "./tests/conf/yaml/test.yaml"])
             config = ConfigArgBuilder(
-                TypeConfig,
-                NestedStuff,
-                NestedListStuff,
-                TypeOptConfig,
-                SingleNestedConfig,
-                FirstDoubleNestedConfig,
-                SecondDoubleNestedConfig,
+                *all_configs,
                 desc="Test Builder",
             )
             return config.generate()

--- a/tests/base/test_state.py
+++ b/tests/base/test_state.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+import datetime
+import os
+import re
+import sys
+
+from spock.builder import ConfigArgBuilder
+from tests.base.attr_configs_test import *
+
+
+class TestSerializedState:
+    def test_serialization_deserialization(self, monkeypatch, tmp_path):
+        """Test serialization/de-serialization"""
+        with monkeypatch.context() as m:
+            m.setattr(
+                sys, "argv", ["", "--config", "./tests/conf/yaml/test.yaml"]
+            )
+            # Serialize
+            config = ConfigArgBuilder(
+                *all_configs,
+                desc="Test Builder",
+            )
+            now = datetime.datetime.now()
+            curr_int_time = int(f"{now.year}{now.month}{now.day}{now.hour}{now.second}")
+            config_values = config.save(
+                file_extension=".yaml",
+                file_name=f"pytest.{curr_int_time}",
+                user_specified_path=tmp_path
+            ).generate()
+            yaml_regex = re.compile(
+                fr"pytest.{curr_int_time}."
+                fr"[a-fA-F0-9]{{8}}-[a-fA-F0-9]{{4}}-[a-fA-F0-9]{{4}}-"
+                fr"[a-fA-F0-9]{{4}}-[a-fA-F0-9]{{12}}.spock.cfg.yaml"
+            )
+            matches = [
+                re.fullmatch(yaml_regex, val)
+                for val in os.listdir(str(tmp_path))
+                if re.fullmatch(yaml_regex, val) is not None
+            ]
+            fname = f"{str(tmp_path)}/{matches[0].string}"
+            # Deserialize
+            m.setattr(
+                sys, "argv", ["", "--config", f"{fname}"]
+            )
+            de_serial_config = ConfigArgBuilder(
+                *all_configs,
+                desc="Test Builder",
+            ).generate()
+            assert config_values == de_serial_config

--- a/tests/base/test_type_specific.py
+++ b/tests/base/test_type_specific.py
@@ -35,13 +35,7 @@ class TestTupleRaises:
             m.setattr(sys, "argv", ["", "--config", "./tests/conf/yaml/tuple.yaml"])
             with pytest.raises(ValueError):
                 ConfigArgBuilder(
-                    TypeConfig,
-                    NestedStuff,
-                    NestedListStuff,
-                    TypeOptConfig,
-                    SingleNestedConfig,
-                    FirstDoubleNestedConfig,
-                    SecondDoubleNestedConfig,
+                    *all_configs,
                     desc="Test Builder")
 
 
@@ -55,6 +49,7 @@ class TestOverrideRaise:
                 ConfigArgBuilder(
                     TypeInherited,
                     NestedStuff,
+                    NestedStuffOpt,
                     NestedListStuff,
                     TypeOptConfig,
                     SingleNestedConfig,
@@ -94,13 +89,7 @@ class TestEnumClassMissing:
             )
             with pytest.raises(KeyError):
                 ConfigArgBuilder(
-                    TypeConfig,
-                    NestedStuff,
-                    NestedListStuff,
-                    TypeOptConfig,
-                    SingleNestedConfig,
-                    FirstDoubleNestedConfig,
-                    SecondDoubleNestedConfig,
+                    *all_configs,
                     desc="Test Builder"
                 )
 

--- a/tests/base/test_writers.py
+++ b/tests/base/test_writers.py
@@ -17,13 +17,7 @@ class TestDefaultWriter:
         with monkeypatch.context() as m:
             m.setattr(sys, "argv", ["", "--config", "./tests/conf/yaml/test.yaml"])
             config = ConfigArgBuilder(
-                TypeConfig,
-                NestedStuff,
-                NestedListStuff,
-                TypeOptConfig,
-                SingleNestedConfig,
-                FirstDoubleNestedConfig,
-                SecondDoubleNestedConfig,
+                *all_configs,
                 desc="Test Builder",
             )
             # Test the chained version
@@ -37,13 +31,7 @@ class TestYAMLWriter:
         with monkeypatch.context() as m:
             m.setattr(sys, "argv", ["", "--config", "./tests/conf/yaml/test.yaml"])
             config = ConfigArgBuilder(
-                TypeConfig,
-                NestedStuff,
-                NestedListStuff,
-                TypeOptConfig,
-                SingleNestedConfig,
-                FirstDoubleNestedConfig,
-                SecondDoubleNestedConfig,
+                *all_configs,
                 desc="Test Builder",
             )
             # Test the chained version
@@ -61,13 +49,7 @@ class TestYAMLWriterCreate:
         with monkeypatch.context() as m:
             m.setattr(sys, "argv", ["", "--config", "./tests/conf/yaml/test.yaml"])
             config = ConfigArgBuilder(
-                TypeConfig,
-                NestedStuff,
-                NestedListStuff,
-                TypeOptConfig,
-                SingleNestedConfig,
-                FirstDoubleNestedConfig,
-                SecondDoubleNestedConfig,
+                *all_configs,
                 desc="Test Builder",
             )
             # Test the chained version
@@ -91,13 +73,7 @@ class TestYAMLWriterSavePath:
                 sys, "argv", ["", "--config", "./tests/conf/yaml/test_save_path.yaml"]
             )
             config = ConfigArgBuilder(
-                TypeConfig,
-                NestedStuff,
-                NestedListStuff,
-                TypeOptConfig,
-                SingleNestedConfig,
-                FirstDoubleNestedConfig,
-                SecondDoubleNestedConfig,
+                *all_configs,
                 desc="Test Builder",
             )
             # Test the chained version
@@ -132,13 +108,7 @@ class TestYAMLWriterNoPath:
             m.setattr(sys, "argv", ["", "--config", "./tests/conf/yaml/test.yaml"])
             with pytest.raises(ValueError):
                 config = ConfigArgBuilder(
-                    TypeConfig,
-                    NestedStuff,
-                    NestedListStuff,
-                    TypeOptConfig,
-                    SingleNestedConfig,
-                    FirstDoubleNestedConfig,
-                    SecondDoubleNestedConfig,
+                    *all_configs,
                     desc="Test Builder",
                 )
                 # Test the chained version
@@ -151,13 +121,7 @@ class TestWritePathRaise:
         with monkeypatch.context() as m:
             m.setattr(sys, "argv", ["", "--config", "./tests/conf/yaml/test.yaml"])
             config = ConfigArgBuilder(
-                TypeConfig,
-                NestedStuff,
-                NestedListStuff,
-                TypeOptConfig,
-                SingleNestedConfig,
-                FirstDoubleNestedConfig,
-                SecondDoubleNestedConfig,
+                *all_configs,
                 desc="Test Builder",
             )
             # Test the chained version
@@ -175,13 +139,7 @@ class TestInvalidExtensionTypeRaise:
         with monkeypatch.context() as m:
             m.setattr(sys, "argv", ["", "--config", "./tests/conf/yaml/test.yaml"])
             config = ConfigArgBuilder(
-                TypeConfig,
-                NestedStuff,
-                NestedListStuff,
-                TypeOptConfig,
-                SingleNestedConfig,
-                FirstDoubleNestedConfig,
-                SecondDoubleNestedConfig,
+                *all_configs,
                 desc="Test Builder",
             )
             # Test the chained version
@@ -198,13 +156,7 @@ class TestTOMLWriter:
         with monkeypatch.context() as m:
             m.setattr(sys, "argv", ["", "--config", "./tests/conf/toml/test.toml"])
             config = ConfigArgBuilder(
-                TypeConfig,
-                NestedStuff,
-                NestedListStuff,
-                TypeOptConfig,
-                SingleNestedConfig,
-                FirstDoubleNestedConfig,
-                SecondDoubleNestedConfig,
+                *all_configs,
                 desc="Test Builder",
             )
             # Test the chained version
@@ -222,13 +174,7 @@ class TestJSONWriter:
         with monkeypatch.context() as m:
             m.setattr(sys, "argv", ["", "--config", "./tests/conf/json/test.json"])
             config = ConfigArgBuilder(
-                TypeConfig,
-                NestedStuff,
-                NestedListStuff,
-                TypeOptConfig,
-                SingleNestedConfig,
-                FirstDoubleNestedConfig,
-                SecondDoubleNestedConfig,
+                *all_configs,
                 desc="Test Builder",
             )
             # Test the chained version

--- a/tests/s3/test_io.py
+++ b/tests/s3/test_io.py
@@ -30,13 +30,7 @@ class TestAllTypesFromS3MockYAML(AllTypes):
                 sys, "argv", ["", "--config", f"s3://{mock_s3_bucket}/{mock_s3_object}"]
             )
             config = ConfigArgBuilder(
-                TypeConfig,
-                NestedStuff,
-                NestedListStuff,
-                TypeOptConfig,
-                SingleNestedConfig,
-                FirstDoubleNestedConfig,
-                SecondDoubleNestedConfig,
+                *all_configs,
                 s3_config=S3Config(session=aws_session, s3_session=s3_client),
                 desc="Test Builder",
             )
@@ -50,13 +44,7 @@ class TestS3MockYAMLWriter:
             aws_session, s3_client = s3
             m.setattr(sys, "argv", ["", "--config", "./tests/conf/yaml/test.yaml"])
             config = ConfigArgBuilder(
-                TypeConfig,
-                NestedStuff,
-                NestedListStuff,
-                TypeOptConfig,
-                SingleNestedConfig,
-                FirstDoubleNestedConfig,
-                SecondDoubleNestedConfig,
+                *all_configs,
                 s3_config=S3Config(session=aws_session, s3_session=s3_client),
                 desc="Test Builder",
             )

--- a/tests/s3/test_raises.py
+++ b/tests/s3/test_raises.py
@@ -27,13 +27,7 @@ class TestAllTypesFromS3MockYAMLMissingS3:
             )
             with pytest.raises(ValueError):
                 config = ConfigArgBuilder(
-                    TypeConfig,
-                    NestedStuff,
-                    NestedListStuff,
-                    TypeOptConfig,
-                    SingleNestedConfig,
-                    FirstDoubleNestedConfig,
-                    SecondDoubleNestedConfig,
+                    *all_configs,
                     desc="Test Builder",
                 )
 
@@ -54,13 +48,7 @@ class TestAllTypesFromS3MockYAMLNoObject:
             m.setattr(sys, "argv", ["", "--config", f"s3://foo/bar.yaml"])
             with pytest.raises(s3_client.exceptions.NoSuchBucket):
                 config = ConfigArgBuilder(
-                    TypeConfig,
-                    NestedStuff,
-                    NestedListStuff,
-                    TypeOptConfig,
-                    SingleNestedConfig,
-                    FirstDoubleNestedConfig,
-                    SecondDoubleNestedConfig,
+                    *all_configs,
                     s3_config=S3Config(session=aws_session, s3_session=s3_client),
                     desc="Test Builder",
                 )
@@ -73,13 +61,7 @@ class TestS3MockYAMLWriterMissingS3:
             aws_session, s3_client = s3
             m.setattr(sys, "argv", ["", "--config", "./tests/conf/yaml/test.yaml"])
             config = ConfigArgBuilder(
-                TypeConfig,
-                NestedStuff,
-                NestedListStuff,
-                TypeOptConfig,
-                SingleNestedConfig,
-                FirstDoubleNestedConfig,
-                SecondDoubleNestedConfig,
+                *all_configs,
                 desc="Test Builder",
             )
             # Mock a S3 bucket and object
@@ -106,13 +88,7 @@ class TestS3MockYAMLWriterNoBucket:
             aws_session, s3_client = s3
             m.setattr(sys, "argv", ["", "--config", "./tests/conf/yaml/test.yaml"])
             config = ConfigArgBuilder(
-                TypeConfig,
-                NestedStuff,
-                NestedListStuff,
-                TypeOptConfig,
-                SingleNestedConfig,
-                FirstDoubleNestedConfig,
-                SecondDoubleNestedConfig,
+                *all_configs,
                 desc="Test Builder",
             )
             # Mock a S3 bucket and object


### PR DESCRIPTION
## What does this PR do?

New graph backend from #181 was causing translation from Spockspace to native python dictionary to fail in certain cases: (1) optional Enum's of `@spock` decorated classes, (2) nested `@spock` classes with definitions coming in from configuration file(s) -- as these were not getting recursed in the config check.

This PR solves both the above issues and adds additional unit tests.

## Checklist
  - [x] Did you adhere to [PEP-8](https://www.python.org/dev/peps/pep-0008/) standards?
  - [x] Did you run black and isort prior to submitting your PR? 
  - [x] Does your PR pass all existing unit tests?
  - [x] Did you add associated unit tests for any additional functionality?
  - [x] Did you provide documentation ([Google Docstring format](https://google.github.io/styleguide/pyguide.html)) whenever possible, even for simple functions or classes?
