### PR TITLE
graph equality bug

### DIFF
--- a/spock/graph.py
+++ b/spock/graph.py
@@ -57,11 +57,12 @@ class Graph:
         """
         # Build a dictionary of all nodes (base spock classes)
         nodes = {val: [] for val in self._input_classes}
+        node_names = [f"{k.__module__}.{k.__name__}" for k in nodes.keys()]
         # Iterate thorough all of the base spock classes to get the dependencies and reverse dependencies
         for input_class in self._input_classes:
             dep_classes = self._find_all_spock_classes(input_class)
             for v in dep_classes:
-                if v not in nodes:
+                if f"{v.__module__}.{v.__name__}" not in node_names:
                     raise ValueError(
                         f"Missing @spock decorated class -- `{v.__name__}` was not passed as an *arg to "
                         f"ConfigArgBuilder"


### PR DESCRIPTION
## What does this PR do?

fix bug where equality was checking using is (which checks memory loc) which prevents class overloading and re-mapping. Switched to a simple module + class name mapping as those should still be unique

## Checklist
  - [x] Did you adhere to [PEP-8](https://www.python.org/dev/peps/pep-0008/) standards?
  - [x] Did you run black and isort prior to submitting your PR? 
  - [x] Does your PR pass all existing unit tests?
  - [x] Did you add associated unit tests for any additional functionality?
  - [x] Did you provide documentation ([Google Docstring format](https://google.github.io/styleguide/pyguide.html)) whenever possible, even for simple functions or classes?