### PR TITLE
Additional Features: Type Hints, Lazy Evaluation, New Top Level Interfaces

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include versioneer.py
 include spock/_version.py
+include "README.md", "LICENSE.txt", "NOTICE.txt", "CONTRIBUTING.md"

--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ hierarchical configuration by composition.
   defined within a `@spock` decorated class. Supports required/optional and automatic defaults.
 * Easily Managed Parameter Groups: Each class automatically generates its own object within a single namespace.
 * [Parameter Inheritance](https://fidelity.github.io/spock/docs/advanced_features/Inheritance/): Classes support 
-  inheritance allowing for complex configurations derived from a common base set of parameters.
+  inheritance (w/ lazy evaluation of inheritance/dependencies) allowing for complex configurations derived from 
+  a common base set of parameters.
 * [Complex Types](https://fidelity.github.io/spock/docs/advanced_features/Advanced-Types/): Nested Lists/Tuples, 
   List/Tuples of Enum of `@spock` classes, List of repeated `@spock` classes
 * Multiple Configuration File Types: Configurations are specified from YAML, TOML, or JSON files.
@@ -66,16 +67,19 @@ Example `spock` usage is located [here](https://github.com/fidelity/spock/blob/m
 
 See [Releases](https://github.com/fidelity/spock/releases) for more information.
 
+#### January 18th, 2022
+* Support for lazy evaluation: (1) inherited classes do not need to be `@spock` decorated, (2) dependencies/references 
+between `spock` classes can be lazily handled thus preventing the need for every `@spock` decorated classes to be 
+passed into `*args` within the main `SpockBuilder` API
+* Updated main API interface for better top-level imports (backwards compatible): `ConfigArgBuilder`->`spockBuilder`
+* Added stubs to the underlying decorator that should help with type hinting in VSCode (pylance/pyright)
+
 #### December 14, 2021
 * Refactored the backend to better handle nested dependencies (and for clarity)
 * Refactored the docs to use Docusaurus
 
 #### August 17, 2021
 * Added hyper-parameter tuning backend support for Ax via Service API
-
-#### July 21, 2021
-* Added hyper-parameter tuning support with `pip install spock-config[tune]`
-* Hyper-parameter tuning backend support for Optuna define-and-run API (WIP for Ax)
 
 ## Original Implementation
 

--- a/examples/quick-start/simple.py
+++ b/examples/quick-start/simple.py
@@ -1,7 +1,7 @@
 from typing import List
 
-from spock.builder import ConfigArgBuilder
-from spock.config import spock
+from spock import SpockBuilder
+from spock import spock
 
 
 @spock
@@ -47,7 +47,7 @@ def add_by_parameter(multiply_param, list_vals, add_param, tf_round):
 
 def main():
     # Chain the generate function to the class call
-    config = ConfigArgBuilder(BasicConfig, desc="Quick start example").generate()
+    config = SpockBuilder(BasicConfig, desc="Quick start example").generate()
     # One can now access the Spock config object by class name with the returned namespace
     print(config.BasicConfig.parameter)
     # And pass the namespace to our first function

--- a/examples/tune/ax/tune.py
+++ b/examples/tune/ax/tune.py
@@ -16,8 +16,8 @@ from spock.addons.tune import (
     RangeHyperParameter,
     spockTuner,
 )
-from spock.builder import ConfigArgBuilder
-from spock.config import spock
+from spock import SpockBuilder
+from spock import spock
 
 
 @spock
@@ -46,7 +46,7 @@ def main():
     # Use the builder to setup
     # Call tuner to indicate that we are going to do some HP tuning -- passing in an ax study object
     attrs_obj = (
-        ConfigArgBuilder(
+        SpockBuilder(
             LogisticRegressionHP,
             BasicParams,
             desc="Example Logistic Regression Hyper-Parameter Tuning -- Ax Backend",

--- a/examples/tune/optuna/tune.py
+++ b/examples/tune/optuna/tune.py
@@ -16,8 +16,8 @@ from spock.addons.tune import (
     RangeHyperParameter,
     spockTuner,
 )
-from spock.builder import ConfigArgBuilder
-from spock.config import spock
+from spock import SpockBuilder
+from spock import spock
 
 
 @spock
@@ -48,7 +48,7 @@ def main():
     # Use the builder to setup
     # Call tuner to indicate that we are going to do some HP tuning -- passing in an optuna study object
     attrs_obj = (
-        ConfigArgBuilder(
+        SpockBuilder(
             LogisticRegressionHP,
             BasicParams,
             desc="Example Logistic Regression Hyper-Parameter Tuning -- Optuna Backend",

--- a/examples/tutorial/advanced/tutorial.py
+++ b/examples/tutorial/advanced/tutorial.py
@@ -4,9 +4,8 @@ from typing import List, Optional, Tuple
 import torch
 from basic_nn import BasicNet
 
-from spock.args import SavePath
-from spock.builder import ConfigArgBuilder
-from spock.config import spock
+from spock import SpockBuilder
+from spock import spock
 
 
 class Activation(Enum):
@@ -22,7 +21,6 @@ class Optimizer(Enum):
 
 @spock
 class ModelConfig:
-    save_path: SavePath
     n_features: int
     dropout: Optional[List[float]]
     hidden_sizes: Tuple[int, int, int] = (32, 32, 32)
@@ -90,7 +88,7 @@ def main():
     # A simple description
     description = "spock Advanced Tutorial"
     # Build out the parser by passing in Spock config objects as *args after description
-    config = ConfigArgBuilder(
+    config = SpockBuilder(
         ModelConfig, DataConfig, SGDConfig, desc=description
     ).generate()
     # Instantiate our neural net using

--- a/examples/tutorial/basic/tutorial.py
+++ b/examples/tutorial/basic/tutorial.py
@@ -4,9 +4,8 @@ from typing import List, Tuple
 import torch
 from basic_nn import BasicNet
 
-from spock.args import SavePath
-from spock.builder import ConfigArgBuilder
-from spock.config import spock
+from spock import SpockBuilder
+from spock import spock
 
 
 class Activation(Enum):
@@ -35,7 +34,6 @@ class ModelConfig:
         activation: choice from the Activation enum of the activation function to use
     """
 
-    save_path: SavePath
     n_features: int
     dropout: List[float]
     hidden_sizes: Tuple[int, int, int]
@@ -47,7 +45,7 @@ def main():
     description = "spock Basic Tutorial"
     # Build out the parser by passing in Spock config objects as *args after description
     config = (
-        ConfigArgBuilder(ModelConfig, desc=description, create_save_path=True)
+        SpockBuilder(ModelConfig, desc=description, create_save_path=True)
         .save(file_extension=".toml")
         .generate()
     )

--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,10 @@ setuptools.setup(
     packages=setuptools.find_packages(
         exclude=["*.tests", "*.tests.*", "tests.*", "tests"]
     ),
+    package_data={
+        "spock": ["py.typed", "*.pyi"],
+    },
+    include_package_data=True,
     python_requires=">=3.6",
     install_requires=install_reqs,
     extras_require={"s3": s3_reqs, "tune": tune_reqs},

--- a/spock/__init__.py
+++ b/spock/__init__.py
@@ -15,14 +15,7 @@ from spock.config import spock, spock_attr
 
 SpockBuilder = ConfigArgBuilder
 
-__all__ = [
-    "args",
-    "builder",
-    "config",
-    "spock",
-    "spock_attr",
-    "SpockBuilder"
-]
+__all__ = ["args", "builder", "config", "spock", "spock_attr", "SpockBuilder"]
 
 __version__ = get_versions()["version"]
 del get_versions

--- a/spock/__init__.py
+++ b/spock/__init__.py
@@ -10,8 +10,19 @@ Please refer to the documentation provided in the README.md
 """
 
 from spock._version import get_versions
+from spock.builder import ConfigArgBuilder
+from spock.config import spock, spock_attr
 
-__all__ = ["args", "builder", "config"]
+SpockBuilder = ConfigArgBuilder
+
+__all__ = [
+    "args",
+    "builder",
+    "config",
+    "spock",
+    "spock_attr",
+    "SpockBuilder"
+]
 
 __version__ = get_versions()["version"]
 del get_versions

--- a/spock/addons/tune/config.py
+++ b/spock/addons/tune/config.py
@@ -80,9 +80,9 @@ def _process_class(cls, kw_only: bool, make_init: bool, dynamic: bool):
 
 
 def _spock_tune(
-        maybe_cls=None,
-        kw_only=True,
-        make_init=True,
+    maybe_cls=None,
+    kw_only=True,
+    make_init=True,
 ):
     """Ovverides basic spock_attr decorator with another name
 
@@ -99,9 +99,7 @@ def _spock_tune(
     """
 
     def wrap(cls):
-        return _process_class(
-            cls, kw_only=kw_only, make_init=make_init, dynamic=False
-        )
+        return _process_class(cls, kw_only=kw_only, make_init=make_init, dynamic=False)
 
     # Note: Taken from dataclass/attr definition(s)
     # maybe_cls's type depends on the usage of the decorator.  It's a class

--- a/spock/addons/tune/config.py
+++ b/spock/addons/tune/config.py
@@ -44,28 +44,72 @@ class OptunaTunerConfig:
     directions: Optional[Sequence[Union[str, optuna.study.StudyDirection]]] = None
 
 
-def _spock_tune(cls):
+def _process_class(cls, kw_only: bool, make_init: bool, dynamic: bool):
+    """Process a given class
+
+    Args:
+        cls: basic class definition
+        kw_only: set kwarg only
+        make_init: make an init function
+        dynamic: allows inherited classes to not be @spock decorated
+
+    Returns:
+        cls with attrs dunder methods added
+
+    """
+    # Handles the MRO and gets old annotations
+    bases, attrs_dict, merged_annotations = _base_attr(cls, kw_only, make_init, dynamic)
+    # Dynamically make an attr class
+    obj = attr.make_class(
+        name=cls.__name__,
+        bases=bases,
+        attrs=attrs_dict,
+        kw_only=kw_only,
+        frozen=True,
+        auto_attribs=True,
+        init=make_init,
+    )
+    # For each class we dynamically create we need to register it within the system modules for pickle to work
+    setattr(sys.modules["spock"].addons.tune.config, obj.__name__, obj)
+    # Swap the __doc__ string from cls to obj
+    obj.__doc__ = cls.__doc__
+    # Set the __init__ function
+    # Handle __annotations__ from the MRO
+    obj.__annotations__ = merged_annotations
+    return obj
+
+
+def _spock_tune(
+        maybe_cls=None,
+        kw_only=True,
+        make_init=True,
+):
     """Ovverides basic spock_attr decorator with another name
 
     Using a different name allows spock to easily determine which parameters are normal and which are
     meant to be used in a hyper-parameter tuning backend
 
     Args:
-        cls: basic class def
+        maybe_cls: maybe a basic class def maybe None depending on call type
+        kw_only: Make all attributes keyword-only
+        make_init: bool, define a __init__() method
 
     Returns:
-        cls: slotted attrs class that is frozen and kw only
+        cls: attrs class that is frozen and kw only
     """
-    bases, attrs_dict = _base_attr(cls)
-    # Dynamically make an attr class
-    obj = attr.make_class(
-        name=cls.__name__, bases=bases, attrs=attrs_dict, kw_only=True, frozen=True
-    )
-    # For each class we dynamically create we need to register it within the system modules for pickle to work
-    setattr(sys.modules["spock"].addons.tune.config, obj.__name__, obj)
-    # Swap the __doc__ string from cls to obj
-    obj.__doc__ = cls.__doc__
-    return obj
+
+    def wrap(cls):
+        return _process_class(
+            cls, kw_only=kw_only, make_init=make_init, dynamic=False
+        )
+
+    # Note: Taken from dataclass/attr definition(s)
+    # maybe_cls's type depends on the usage of the decorator.  It's a class
+    # if it's used as `@spockTuner` but ``None`` if used as `@spockTuner()`.
+    if maybe_cls is None:
+        return wrap
+    else:
+        return wrap(maybe_cls)
 
 
 # Make the alias for the decorator

--- a/spock/addons/tune/config.pyi
+++ b/spock/addons/tune/config.pyi
@@ -1,0 +1,39 @@
+from typing import Any, Callable, Tuple, TypeVar, Union, overload
+
+from attr import attrib, field
+
+_T = TypeVar("_T")
+_C = TypeVar("_C", bound=type)
+
+# Note: from here
+# https://github.com/python-attrs/attrs/blob/main/src/attr/__init__.pyi
+
+# Static type inference support via __dataclass_transform__ implemented as per:
+# https://github.com/microsoft/pyright/blob/main/specs/dataclass_transforms.md
+# This annotation must be applied to all overloads of "spock_attr"
+
+# NOTE: This is a typing construct and does not exist at runtime.  Extensions
+# wrapping attrs decorators should declare a separate __dataclass_transform__
+# signature in the extension module using the specification linked above to
+# provide pyright support -- this currently doesn't work in PyCharm
+def __dataclass_transform__(
+    *,
+    eq_default: bool = True,
+    order_default: bool = False,
+    kw_only_default: bool = False,
+    field_descriptors: Tuple[Union[type, Callable[..., Any]], ...] = (()),
+) -> Callable[[_T], _T]: ...
+@overload
+@__dataclass_transform__(kw_only_default=True, field_descriptors=(attrib, field))
+def _spock_tune(
+    maybe_cls: _C,
+    kw_only: bool = True,
+    make_init: bool = True,
+) -> _C: ...
+@overload
+@__dataclass_transform__(kw_only_default=True, field_descriptors=(attrib, field))
+def _spock_tune(
+    maybe_cls: None = ...,
+    kw_only: bool = True,
+    make_init: bool = True,
+) -> Callable[[_C], _C]: ...

--- a/spock/backend/builder.py
+++ b/spock/backend/builder.py
@@ -37,7 +37,9 @@ class BaseBuilder(ABC):  # pylint: disable=too-few-public-methods
 
     """
 
-    def __init__(self, *args, max_indent: int = 4, module_name: str, lazy: bool, **kwargs):
+    def __init__(
+        self, *args, max_indent: int = 4, module_name: str, lazy: bool, **kwargs
+    ):
         """Init call for BaseBuilder
 
         Args:

--- a/spock/backend/config.py
+++ b/spock/backend/config.py
@@ -10,60 +10,137 @@ import sys
 import attr
 
 from spock.backend.typed import katra
+from spock.utils import _is_spock_instance
+from spock.exceptions import _SpockUndecoratedClass
 
 
-def _base_attr(cls):
+def _base_attr(cls, kw_only: bool, make_init: bool, dynamic: bool):
     """Map type hints to katras
 
     Connector function that maps type hinting style to the defined katra style which uses the more strict
     attr.ib() definition
 
+    Handles dynamic decorators which allows for inheritance of non @spock decorated classes
+
     Args:
         cls: basic class def
+        dynamic: allows inherited classes to not be @spock decorated
 
     Returns:
-        cls: slotted attrs class that is frozen and kw only
+        cls: base spock classes derived from the MRO
+        attrs_dict: the current dictionary of attr.attribute values
+        merged_annotations: dictionary of type annotations
+
     """
     # Since we are not using the @attr.s decorator we need to get the parent classes for inheritance
     # We do this by using the mro and grabbing anything that is not the first and last indices in the list and wrapping
     # it into a tuple
+    bases = ()
+    base_annotation = {}
+    base_defaults = {}
     if len(cls.__mro__[1:-1]) > 0:
-        bases = tuple(cls.__mro__[1:-1])
-    # if there are not parents pass a blank tuple
+        # Get bases minus self and python class object
+        bases = list(cls.__mro__[1:-1])
+        for idx, base_cls in enumerate(bases):
+            if not _is_spock_instance(base_cls) and not dynamic:
+                raise _SpockUndecoratedClass(
+                    f"Class `{base_cls.__name__}` was not decorated with the @spock decorator "
+                    f"and `dynamic={dynamic}` was set for child class `{cls.__name__}`")
+            elif not _is_spock_instance(base_cls) and dynamic:
+                bases[idx] = _process_class(base_cls, kw_only, make_init, dynamic)
+        bases = tuple(bases)
+        base_annotation = {}
+        for val in bases:
+            for attribute in val.__attrs_attrs__:
+                # Since we are moving left to right via the MRO only update if not currently present
+                # this maintains parity to how the MRO is handled in base python
+                if attribute.name not in base_annotation:
+                    if 'type' in attribute.metadata:
+                        base_annotation.update({attribute.name: attribute.metadata['og_type']})
+                    else:
+                        base_annotation.update({attribute.name: attribute.type})
+        base_defaults = {attribute.name: attribute.default for val in bases for attribute in val.__attrs_attrs__ if attribute.default is not (None or attr.NOTHING)}
+    # Merge the annotations -- always override as this is the lowest level of the MRO
+    if hasattr(cls, '__annotations__'):
+        new_annotations = {k: v for k, v in cls.__annotations__.items()}
     else:
-        bases = ()
+        new_annotations = {}
+    merged_annotations = {**base_annotation, **new_annotations}
+
     # Make a blank attrs dict for new attrs
     attrs_dict = {}
-    if hasattr(cls, "__annotations__"):
-        for k, v in cls.__annotations__.items():
-            # If the cls has the attribute then a default was set
-            if hasattr(cls, k):
-                default = getattr(cls, k)
-            else:
-                default = None
-            attrs_dict.update({k: katra(typed=v, default=default)})
-    return bases, attrs_dict
+
+    for k, v in merged_annotations.items():
+        # If the cls has the attribute then a default was set
+        if hasattr(cls, k):
+            default = getattr(cls, k)
+        elif k in base_defaults:
+            default = base_defaults[k]
+        else:
+            default = None
+        attrs_dict.update({k: katra(typed=v, default=default)})
+    return bases, attrs_dict, merged_annotations
 
 
-def spock_attr(cls):
-    """Map type hints to katras
-
-    Connector function that maps type hinting style to the defined katra style which uses the more strict
-    attr.ib() definition
+def _process_class(cls, kw_only: bool, make_init: bool, dynamic: bool):
+    """Process a given class
 
     Args:
-        cls: basic class def
+        cls: basic class definition
+        kw_only: set kwarg only
+        make_init: make an init function
+        dynamic: allows inherited classes to not be @spock decorated
 
     Returns:
-        cls: slotted attrs class that is frozen and kw only
+        cls with attrs dunder methods added
+
     """
-    bases, attrs_dict = _base_attr(cls)
+    # Handles the MRO and gets old annotations
+    bases, attrs_dict, merged_annotations = _base_attr(cls, kw_only, make_init, dynamic)
     # Dynamically make an attr class
     obj = attr.make_class(
-        name=cls.__name__, bases=bases, attrs=attrs_dict, kw_only=True, frozen=True
+        name=cls.__name__, bases=bases, attrs=attrs_dict, kw_only=kw_only, frozen=True, auto_attribs=True,
+        init=make_init
     )
     # For each class we dynamically create we need to register it within the system modules for pickle to work
     setattr(sys.modules["spock"].backend.config, obj.__name__, obj)
     # Swap the __doc__ string from cls to obj
     obj.__doc__ = cls.__doc__
+    # Set the __init__ function
+    # Handle __annotations__ from the MRO
+    obj.__annotations__ = merged_annotations
     return obj
+
+
+def spock_attr(
+        maybe_cls=None,
+        kw_only=True,
+        make_init=True,
+        dynamic=False,
+):
+    """Map type hints to katras
+
+    Connector function that maps type hinting style to the defined katra style which uses the more strict
+    attr.ib() definition -- this allows us to attach the correct validators for types before the attrs class is
+    built
+
+    Args:
+        maybe_cls: maybe a basic class def maybe None depending on call type
+        kw_only: Make all attributes keyword-only
+        make_init: bool, define a __init__() method
+        dynamic: allows inherited classes to not be @spock decorated -- will automatically cast parent classes to a
+            spock class by traversing the MRO
+
+    Returns:
+        cls: attrs class that is frozen and kw only
+    """
+
+    def wrap(cls):
+        return _process_class(cls, kw_only=kw_only, make_init=make_init, dynamic=dynamic)
+    # Note: Taken from dataclass/attr definition(s)
+    # maybe_cls's type depends on the usage of the decorator.  It's a class
+    # if it's used as `@spock` but ``None`` if used as `@spock()`.
+    if maybe_cls is None:
+        return wrap
+    else:
+        return wrap(maybe_cls)

--- a/spock/backend/config.py
+++ b/spock/backend/config.py
@@ -14,7 +14,7 @@ from spock.exceptions import _SpockUndecoratedClass
 from spock.utils import _is_spock_instance
 
 
-def _base_attr(cls, kw_only: bool, make_init: bool, dynamic: bool):
+def _base_attr(cls, kw_only, make_init, dynamic):
     """Map type hints to katras
 
     Connector function that maps type hinting style to the defined katra style which uses the more strict

--- a/spock/backend/config.py
+++ b/spock/backend/config.py
@@ -45,7 +45,7 @@ def _base_attr(cls, kw_only, make_init, dynamic):
             if not _is_spock_instance(base_cls) and not dynamic:
                 raise _SpockUndecoratedClass(
                     f"Class `{base_cls.__name__}` was not decorated with the @spock decorator "
-                    f"and `dynamic={dynamic}` was set for child class `{cls.__name__}`"
+                    f"and `dynamic={dynamic}` was set for child class `{cls.__name__}` -- Please remedy one of these"
                 )
             elif not _is_spock_instance(base_cls) and dynamic:
                 bases[idx] = _process_class(base_cls, kw_only, make_init, dynamic)

--- a/spock/backend/config.py
+++ b/spock/backend/config.py
@@ -10,8 +10,8 @@ import sys
 import attr
 
 from spock.backend.typed import katra
-from spock.utils import _is_spock_instance
 from spock.exceptions import _SpockUndecoratedClass
+from spock.utils import _is_spock_instance
 
 
 def _base_attr(cls, kw_only: bool, make_init: bool, dynamic: bool):
@@ -45,7 +45,8 @@ def _base_attr(cls, kw_only: bool, make_init: bool, dynamic: bool):
             if not _is_spock_instance(base_cls) and not dynamic:
                 raise _SpockUndecoratedClass(
                     f"Class `{base_cls.__name__}` was not decorated with the @spock decorator "
-                    f"and `dynamic={dynamic}` was set for child class `{cls.__name__}`")
+                    f"and `dynamic={dynamic}` was set for child class `{cls.__name__}`"
+                )
             elif not _is_spock_instance(base_cls) and dynamic:
                 bases[idx] = _process_class(base_cls, kw_only, make_init, dynamic)
         bases = tuple(bases)
@@ -55,13 +56,20 @@ def _base_attr(cls, kw_only: bool, make_init: bool, dynamic: bool):
                 # Since we are moving left to right via the MRO only update if not currently present
                 # this maintains parity to how the MRO is handled in base python
                 if attribute.name not in base_annotation:
-                    if 'type' in attribute.metadata:
-                        base_annotation.update({attribute.name: attribute.metadata['og_type']})
+                    if "type" in attribute.metadata:
+                        base_annotation.update(
+                            {attribute.name: attribute.metadata["og_type"]}
+                        )
                     else:
                         base_annotation.update({attribute.name: attribute.type})
-        base_defaults = {attribute.name: attribute.default for val in bases for attribute in val.__attrs_attrs__ if attribute.default is not (None or attr.NOTHING)}
+        base_defaults = {
+            attribute.name: attribute.default
+            for val in bases
+            for attribute in val.__attrs_attrs__
+            if attribute.default is not (None or attr.NOTHING)
+        }
     # Merge the annotations -- always override as this is the lowest level of the MRO
-    if hasattr(cls, '__annotations__'):
+    if hasattr(cls, "__annotations__"):
         new_annotations = {k: v for k, v in cls.__annotations__.items()}
     else:
         new_annotations = {}
@@ -99,8 +107,13 @@ def _process_class(cls, kw_only: bool, make_init: bool, dynamic: bool):
     bases, attrs_dict, merged_annotations = _base_attr(cls, kw_only, make_init, dynamic)
     # Dynamically make an attr class
     obj = attr.make_class(
-        name=cls.__name__, bases=bases, attrs=attrs_dict, kw_only=kw_only, frozen=True, auto_attribs=True,
-        init=make_init
+        name=cls.__name__,
+        bases=bases,
+        attrs=attrs_dict,
+        kw_only=kw_only,
+        frozen=True,
+        auto_attribs=True,
+        init=make_init,
     )
     # For each class we dynamically create we need to register it within the system modules for pickle to work
     setattr(sys.modules["spock"].backend.config, obj.__name__, obj)
@@ -113,10 +126,10 @@ def _process_class(cls, kw_only: bool, make_init: bool, dynamic: bool):
 
 
 def spock_attr(
-        maybe_cls=None,
-        kw_only=True,
-        make_init=True,
-        dynamic=False,
+    maybe_cls=None,
+    kw_only=True,
+    make_init=True,
+    dynamic=False,
 ):
     """Map type hints to katras
 
@@ -136,7 +149,10 @@ def spock_attr(
     """
 
     def wrap(cls):
-        return _process_class(cls, kw_only=kw_only, make_init=make_init, dynamic=dynamic)
+        return _process_class(
+            cls, kw_only=kw_only, make_init=make_init, dynamic=dynamic
+        )
+
     # Note: Taken from dataclass/attr definition(s)
     # maybe_cls's type depends on the usage of the decorator.  It's a class
     # if it's used as `@spock` but ``None`` if used as `@spock()`.

--- a/spock/backend/config.pyi
+++ b/spock/backend/config.pyi
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Tuple, TypeVar, Union, overload
+from typing import Any, Callable, Tuple, TypeVar, Union, overload, List, Dict
 
 from attr import attrib, field
 
@@ -39,3 +39,10 @@ def spock_attr(
     make_init: bool = True,
     dynamic: bool = False,
 ) -> Callable[[_C], _C]: ...
+
+def _base_attr(
+    cls: _C,
+    kw_only: bool = ...,
+    make_init: bool = ...,
+    dynamic: bool = ...,
+) -> (List[_C], Dict, Dict): ...

--- a/spock/backend/config.pyi
+++ b/spock/backend/config.pyi
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Tuple, TypeVar, Union, overload, List, Dict
+from typing import Any, Callable, Dict, List, Tuple, TypeVar, Union, overload
 
 from attr import attrib, field
 
@@ -39,7 +39,6 @@ def spock_attr(
     make_init: bool = True,
     dynamic: bool = False,
 ) -> Callable[[_C], _C]: ...
-
 def _base_attr(
     cls: _C,
     kw_only: bool = ...,

--- a/spock/backend/config.pyi
+++ b/spock/backend/config.pyi
@@ -1,0 +1,52 @@
+from typing import (
+    Any,
+    Callable,
+    Tuple,
+    TypeVar,
+    Union,
+    overload,
+)
+
+from attr import attrib, field
+
+_T = TypeVar("_T")
+_C = TypeVar("_C", bound=type)
+
+# Note: from here
+# https://github.com/python-attrs/attrs/blob/main/src/attr/__init__.pyi
+
+# Static type inference support via __dataclass_transform__ implemented as per:
+# https://github.com/microsoft/pyright/blob/main/specs/dataclass_transforms.md
+# This annotation must be applied to all overloads of "spock_attr"
+
+# NOTE: This is a typing construct and does not exist at runtime.  Extensions
+# wrapping attrs decorators should declare a separate __dataclass_transform__
+# signature in the extension module using the specification linked above to
+# provide pyright support -- this currently doesn't work in PyCharm
+def __dataclass_transform__(
+    *,
+    eq_default: bool = True,
+    order_default: bool = False,
+    kw_only_default: bool = False,
+    field_descriptors: Tuple[Union[type, Callable[..., Any]], ...] = (()),
+) -> Callable[[_T], _T]: ...
+
+
+@overload
+@__dataclass_transform__(kw_only_default=True, field_descriptors=(attrib, field))
+def spock_attr(
+        maybe_cls: _C,
+        kw_only: bool = True,
+        make_init: bool = True,
+        dynamic: bool = False,
+) -> _C: ...
+
+
+@overload
+@__dataclass_transform__(kw_only_default=True, field_descriptors=(attrib, field))
+def spock_attr(
+        maybe_cls: None = ...,
+        kw_only: bool = True,
+        make_init: bool = True,
+        dynamic: bool = False,
+) -> Callable[[_C], _C]: ...

--- a/spock/backend/config.pyi
+++ b/spock/backend/config.pyi
@@ -1,11 +1,4 @@
-from typing import (
-    Any,
-    Callable,
-    Tuple,
-    TypeVar,
-    Union,
-    overload,
-)
+from typing import Any, Callable, Tuple, TypeVar, Union, overload
 
 from attr import attrib, field
 
@@ -30,23 +23,19 @@ def __dataclass_transform__(
     kw_only_default: bool = False,
     field_descriptors: Tuple[Union[type, Callable[..., Any]], ...] = (()),
 ) -> Callable[[_T], _T]: ...
-
-
 @overload
 @__dataclass_transform__(kw_only_default=True, field_descriptors=(attrib, field))
 def spock_attr(
-        maybe_cls: _C,
-        kw_only: bool = True,
-        make_init: bool = True,
-        dynamic: bool = False,
+    maybe_cls: _C,
+    kw_only: bool = True,
+    make_init: bool = True,
+    dynamic: bool = False,
 ) -> _C: ...
-
-
 @overload
 @__dataclass_transform__(kw_only_default=True, field_descriptors=(attrib, field))
 def spock_attr(
-        maybe_cls: None = ...,
-        kw_only: bool = True,
-        make_init: bool = True,
-        dynamic: bool = False,
+    maybe_cls: None = ...,
+    kw_only: bool = True,
+    make_init: bool = True,
+    dynamic: bool = False,
 ) -> Callable[[_C], _C]: ...

--- a/spock/backend/field_handlers.py
+++ b/spock/backend/field_handlers.py
@@ -13,19 +13,8 @@ from attr import NOTHING, Attribute
 
 from spock.args import SpockArguments
 from spock.backend.spaces import AttributeSpace, BuilderSpace, ConfigSpace
+from spock.exceptions import _SpockInstantiationError, _SpockNotOptionalError
 from spock.utils import _check_iterable, _is_spock_instance, _is_spock_tune_instance
-
-
-class SpockInstantiationError(Exception):
-    """Custom exception for when the spock class cannot be instantiated correctly"""
-
-    pass
-
-
-class SpockNotOptionalError(Exception):
-    """Custom exception for missing value"""
-
-    pass
 
 
 class RegisterFieldTemplate(ABC):
@@ -216,7 +205,7 @@ class RegisterList(RegisterFieldTemplate):
                         val() if type(val) is type else val for val in attr_space.field
                     ]
                 except Exception as e:
-                    raise SpockInstantiationError(
+                    raise _SpockInstantiationError(
                         f"Spock class `{spock_cls.__name__}` could not be instantiated -- attrs message: {e}"
                     )
                 builder_space.spock_space[spock_cls.__name__] = attr_space.field
@@ -370,10 +359,14 @@ class RegisterSimpleField(RegisterFieldTemplate):
             builder_space: named_tuple containing the arguments and spock_space
 
         Raises:
-            SpockNotOptionalError
+            _SpockNotOptionalError
 
         """
-        raise SpockNotOptionalError()
+        raise _SpockNotOptionalError(
+            f"Parameter `{attr_space.attribute.name}` within `{attr_space.config_space.name}` is of "
+            f"type `{type(attr_space.attribute.type)}` which seems to be unsupported -- "
+            f"are you missing an @spock decorator on a base python class?"
+        )
 
     def handle_optional_attribute_value(
         self, attr_space: AttributeSpace, builder_space: BuilderSpace
@@ -463,10 +456,10 @@ class RegisterTuneCls(RegisterFieldTemplate):
             builder_space: named_tuple containing the arguments and spock_space
 
         Raises:
-            SpockNotOptionalError
+            _SpockNotOptionalError
 
         """
-        raise SpockNotOptionalError()
+        raise _SpockNotOptionalError()
 
     def handle_optional_attribute_type(
         self, attr_space: AttributeSpace, builder_space: BuilderSpace
@@ -478,10 +471,10 @@ class RegisterTuneCls(RegisterFieldTemplate):
             builder_space: named_tuple containing the arguments and spock_space
 
         Raises:
-            SpockNotOptionalError
+            _SpockNotOptionalError
 
         """
-        raise SpockNotOptionalError()
+        raise _SpockNotOptionalError()
 
 
 class RegisterSpockCls(RegisterFieldTemplate):
@@ -625,7 +618,7 @@ class RegisterSpockCls(RegisterFieldTemplate):
         try:
             spock_instance = spock_cls(**fields)
         except Exception as e:
-            raise SpockInstantiationError(
+            raise _SpockInstantiationError(
                 f"Spock class `{spock_cls.__name__}` could not be instantiated -- attrs message: {e}"
             )
         return spock_instance, special_keys

--- a/spock/backend/typed.py
+++ b/spock/backend/typed.py
@@ -463,4 +463,6 @@ def katra(typed, default=None):
         x = _enum_katra(typed=typed, default=default, optional=optional)
     else:
         x = _type_katra(typed=typed, default=default, optional=optional)
+    # Add back in the OG type
+    x.metadata.update({'og_type': typed})
     return x

--- a/spock/backend/typed.py
+++ b/spock/backend/typed.py
@@ -464,5 +464,5 @@ def katra(typed, default=None):
     else:
         x = _type_katra(typed=typed, default=default, optional=optional)
     # Add back in the OG type
-    x.metadata.update({'og_type': typed})
+    x.metadata.update({"og_type": typed})
     return x

--- a/spock/builder.py
+++ b/spock/builder.py
@@ -229,8 +229,7 @@ class ConfigArgBuilder:
         if sys_exit:
             sys.exit(exit_code)
 
-    @staticmethod
-    def _handle_tuner_objects(tune_args, s3_config, kwargs):
+    def _handle_tuner_objects(self, tune_args, s3_config, kwargs):
         """Handles creating the tuner builder object if @spockTuner classes were passed in
 
         Args:
@@ -247,7 +246,7 @@ class ConfigArgBuilder:
                 from spock.addons.tune.builder import TunerBuilder
                 from spock.addons.tune.payload import TunerPayload
 
-                tuner_builder = TunerBuilder(*tune_args, **kwargs)
+                tuner_builder = TunerBuilder(*tune_args, **kwargs, lazy=self._lazy)
                 tuner_payload = TunerPayload(s3_config=s3_config)
                 return tuner_builder, tuner_payload
             except ImportError:

--- a/spock/builder.py
+++ b/spock/builder.py
@@ -42,6 +42,11 @@ class ConfigArgBuilder:
         _tune_namespace: namespace that hold the generated tuner related parameters
         _sample_count: current call to the sample function
         _fixed_uuid: fixed uuid to write the best file to the same path
+        _configs = configs if configs is None else [Path(c) for c in configs]
+        _lazy: flag to lazily find @spock decorated classes registered within sys.modules["spock"].backend.config
+            thus alleviating the need to pass all @spock decorated classes to *args
+        _no_cmd_line: turn off cmd line args
+        _desc: description for help
 
     """
 
@@ -50,6 +55,7 @@ class ConfigArgBuilder:
         *args,
         configs: typing.Optional[typing.List] = None,
         desc: str = "",
+        lazy: bool = False,
         no_cmd_line: bool = False,
         s3_config=None,
         **kwargs,
@@ -60,6 +66,8 @@ class ConfigArgBuilder:
             *args: tuple of spock decorated classes to process
             configs: list of config paths
             desc: description for help
+            lazy: attempts to lazily find @spock decorated classes registered within sys.modules["spock"].backend.config
+            thus alleviating the need to pass all @spock decorated classes to *args
             no_cmd_line: turn off cmd line args
             s3_config: s3Config object for S3 support
             **kwargs: keyword args
@@ -68,6 +76,7 @@ class ConfigArgBuilder:
         # Do some verification first
         self._verify_attr(args)
         self._configs = configs if configs is None else [Path(c) for c in configs]
+        self._lazy = lazy
         self._no_cmd_line = no_cmd_line
         self._desc = desc
         # Build the payload and saver objects
@@ -76,7 +85,7 @@ class ConfigArgBuilder:
         # Split the fixed parameters from the tuneable ones (if present)
         fixed_args, tune_args = self._strip_tune_parameters(args)
         # The fixed parameter builder
-        self._builder_obj = AttrBuilder(*fixed_args, **kwargs)
+        self._builder_obj = AttrBuilder(*fixed_args, lazy=lazy, **kwargs)
         # The possible tunable parameter builder -- might return None
         self._tune_obj, self._tune_payload_obj = self._handle_tuner_objects(
             tune_args, s3_config, kwargs

--- a/spock/builder.py
+++ b/spock/builder.py
@@ -67,6 +67,7 @@ class ConfigArgBuilder:
             configs: list of config paths
             desc: description for help
             lazy: attempts to lazily find @spock decorated classes registered within sys.modules["spock"].backend.config
+            as well as the parents of any lazily inherited @spock class
             thus alleviating the need to pass all @spock decorated classes to *args
             no_cmd_line: turn off cmd line args
             s3_config: s3Config object for S3 support

--- a/spock/exceptions.py
+++ b/spock/exceptions.py
@@ -3,3 +3,15 @@ class _SpockUndecoratedClass(Exception):
     """Custom exception type for non spock decorated classes and not dynamic"""
 
     pass
+
+
+class _SpockInstantiationError(Exception):
+    """Custom exception for when the spock class cannot be instantiated correctly"""
+
+    pass
+
+
+class _SpockNotOptionalError(Exception):
+    """Custom exception for missing value"""
+
+    pass

--- a/spock/exceptions.py
+++ b/spock/exceptions.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+class _SpockUndecoratedClass(Exception):
+    """Custom exception type for non spock decorated classes and not dynamic"""
+
+    pass

--- a/spock/graph.py
+++ b/spock/graph.py
@@ -5,9 +5,8 @@
 
 """Handles creation and ops for DAGs"""
 
-from typing import Type
-
 import sys
+from typing import Type
 from warnings import warn
 
 from spock.utils import _find_all_spock_classes
@@ -34,7 +33,10 @@ class Graph:
         self._lazy = lazy
         # Maybe find classes lazily -- roll them into the input class tuple
         if self._lazy:
-            self._input_classes = (*self._input_classes, *self._lazily_find_classes(self._input_classes))
+            self._input_classes = (
+                *self._input_classes,
+                *self._lazily_find_classes(self._input_classes),
+            )
         # Build -- post lazy eval
         self._dag = self._build()
         # Validate (No cycles in DAG)
@@ -99,9 +101,11 @@ class Graph:
         lazy_classes = []
         for _, v in self._yield_class_deps(classes):
             if hasattr(sys.modules["spock"].backend.config, v):
-                warn(f"Lazy evaluation found a @spock decorated class named `{v}` within the registered types of "
-                     f"sys.modules['spock'].backend.config -- Attempting to use the class "
-                     f"`{getattr(sys.modules['spock'].backend.config, v)}`...")
+                warn(
+                    f"Lazy evaluation found a @spock decorated class named `{v}` within the registered types of "
+                    f"sys.modules['spock'].backend.config -- Attempting to use the class "
+                    f"`{getattr(sys.modules['spock'].backend.config, v)}`..."
+                )
                 # Get the lazily discovered class
                 lazy_class = getattr(sys.modules["spock"].backend.config, v)
                 # Recursive check the lazy class for other lazy classes

--- a/spock/handlers.py
+++ b/spock/handlers.py
@@ -16,8 +16,10 @@ from warnings import warn
 import pytomlpp
 import yaml
 
-from spock import __version__
+from spock._version import get_versions
 from spock.utils import check_path_s3, path_object_to_s3path
+
+__version__ = get_versions()["version"]
 
 
 class Handler(ABC):

--- a/spock/py.typed
+++ b/spock/py.typed
@@ -1,0 +1,1 @@
+partial

--- a/tests/base/attr_configs_test.py
+++ b/tests/base/attr_configs_test.py
@@ -335,3 +335,20 @@ all_configs = [
     SecondDoubleNestedConfig,
     NestedStuffOpt
 ]
+
+
+@spock
+class OtherBar:
+    hello: str = 'goodbye'
+
+
+@spock
+class RaiseNotFlagged:
+    test: int = 1
+    other: OtherBar = OtherBar
+
+
+@spock
+class RaiseNotDecorated:
+    test: int = 1
+    other: Bar = Bar

--- a/tests/base/attr_configs_test.py
+++ b/tests/base/attr_configs_test.py
@@ -304,10 +304,25 @@ class TypeDefaultOptConfig:
 
 
 @spock
+# class TypeInherited(TypeDefaultOptConfig, TypeConfig):
 class TypeInherited(TypeConfig, TypeDefaultOptConfig):
     """This tests inheritance with mixed default and non-default arguments"""
+    pass
 
-    ...
+
+class Foo:
+    p: int = 1
+
+
+class Bar:
+    q: str = 'shhh'
+
+
+@spock(dynamic=True)
+class TestConfigDynamicDefaults(Foo, Bar):
+    x: int = 235
+    y: str = 'yarghhh'
+    z: List[int] = [10, 20]
 
 
 all_configs = [

--- a/tests/base/base_asserts_test.py
+++ b/tests/base/base_asserts_test.py
@@ -220,3 +220,12 @@ class AllInherited:
         assert arg_builder.TypeInherited.tuple_p_opt_def_int == (10, 20)
         assert arg_builder.TypeInherited.tuple_p_opt_def_str == ("Spock", "Package")
         assert arg_builder.TypeInherited.tuple_p_opt_def_bool == (True, False)
+
+
+class AllDynamic:
+    def test_all_dynamic(self, arg_builder):
+        assert arg_builder.TestConfigDynamicDefaults.x == 235
+        assert arg_builder.TestConfigDynamicDefaults.y == "yarghhh"
+        assert arg_builder.TestConfigDynamicDefaults.z == [10, 20]
+        assert arg_builder.TestConfigDynamicDefaults.p == 1
+        assert arg_builder.TestConfigDynamicDefaults.q == 'shhh'

--- a/tests/base/test_config_arg_builder.py
+++ b/tests/base/test_config_arg_builder.py
@@ -194,3 +194,15 @@ class TestWrongRepeatedClass:
                 ConfigArgBuilder(
                     *all_configs, desc="Test Builder"
                 )
+
+
+class TestDynamic(AllDynamic):
+    """Testing basic functionality"""
+
+    @staticmethod
+    @pytest.fixture
+    def arg_builder(monkeypatch):
+        with monkeypatch.context() as m:
+            m.setattr(sys, "argv", [""])
+            config = ConfigArgBuilder(TestConfigDynamicDefaults)
+            return config.generate()

--- a/tests/base/test_config_arg_builder.py
+++ b/tests/base/test_config_arg_builder.py
@@ -4,6 +4,7 @@ import sys
 import pytest
 
 from spock.builder import ConfigArgBuilder
+from spock.exceptions import _SpockUndecoratedClass, _SpockNotOptionalError
 from tests.base.attr_configs_test import *
 from tests.base.base_asserts_test import *
 
@@ -206,3 +207,62 @@ class TestDynamic(AllDynamic):
             m.setattr(sys, "argv", [""])
             config = ConfigArgBuilder(TestConfigDynamicDefaults)
             return config.generate()
+
+
+class TestBasicLazy(AllTypes):
+    """Testing basic lazy evaluation"""
+    @staticmethod
+    @pytest.fixture
+    def arg_builder(monkeypatch):
+        with monkeypatch.context() as m:
+            m.setattr(sys, "argv", ["", "--config", "./tests/conf/yaml/test.yaml"])
+            config = ConfigArgBuilder(TypeConfig, TypeOptConfig, lazy=True)
+            return config.generate()
+
+
+class TestLazyNotFlagged:
+    """Testing failed lazy evaluation"""
+    def test_lazy_raise(self, monkeypatch):
+        with monkeypatch.context() as m:
+            m.setattr(sys, "argv", [""])
+            with pytest.raises(ValueError):
+                config = ConfigArgBuilder(RaiseNotFlagged, lazy=False)
+                config.generate()
+
+
+class TestLazyNotDecorated:
+    """Testing failed lazy evaluation"""
+    def test_lazy_raise(self, monkeypatch):
+        with monkeypatch.context() as m:
+            m.setattr(sys, "argv", [""])
+            with pytest.raises(_SpockNotOptionalError):
+                config = ConfigArgBuilder(RaiseNotDecorated, lazy=False)
+                config.generate()
+
+
+class TestDynamic(AllDynamic):
+    """Testing basic dynamic inheritance"""
+    @staticmethod
+    @pytest.fixture
+    def arg_builder(monkeypatch):
+        with monkeypatch.context() as m:
+            m.setattr(sys, "argv", [""])
+            config = ConfigArgBuilder(TestConfigDynamicDefaults)
+            return config.generate()
+
+
+class TestDynamicRaise:
+    """Testing dynamic raise fail"""
+    def test_dynamic_raise(self, monkeypatch):
+        with monkeypatch.context() as m:
+            m.setattr(sys, "argv", [""])
+            with pytest.raises(_SpockUndecoratedClass):
+
+                @spock
+                class TestConfigDefaultsFail(Foo, Bar):
+                    x: int = 235
+                    y: str = 'yarghhh'
+                    z: List[int] = [10, 20]
+
+                config = ConfigArgBuilder(TestConfigDefaultsFail)
+                return config.generate()

--- a/tests/base/test_type_specific.py
+++ b/tests/base/test_type_specific.py
@@ -4,7 +4,7 @@ import sys
 import pytest
 
 from spock.builder import ConfigArgBuilder
-from spock.backend.field_handlers import SpockInstantiationError
+from spock.exceptions import _SpockInstantiationError
 from tests.base.attr_configs_test import *
 
 
@@ -14,7 +14,7 @@ class TestChoiceRaises:
     def test_choice_raise(self, monkeypatch):
         with monkeypatch.context() as m:
             m.setattr(sys, "argv", ["", "--config", "./tests/conf/yaml/choice.yaml"])
-            with pytest.raises(SpockInstantiationError):
+            with pytest.raises(_SpockInstantiationError):
                 ConfigArgBuilder(ChoiceFail, desc="Test Builder")
 
 
@@ -23,7 +23,7 @@ class TestOptionalRaises:
     def test_coptional_raise(self, monkeypatch):
         with monkeypatch.context() as m:
             # m.setattr(sys, "argv", ["", "--config", "./tests/conf/yaml/empty.yaml"])
-            with pytest.raises(SpockInstantiationError):
+            with pytest.raises(_SpockInstantiationError):
                 ConfigArgBuilder(OptionalFail, desc="Test Builder", configs=[], no_cmd_line=True)
 
 
@@ -108,6 +108,6 @@ class TestMissingRepeatedDefs:
                 "argv",
                 [""],
             )
-            with pytest.raises(SpockInstantiationError):
+            with pytest.raises(_SpockInstantiationError):
                 config = ConfigArgBuilder(RepeatedDefsFailConfig, NestedListStuff, desc="Test Builder")
                 config.generate()

--- a/website/docs/ArgParser-Replacement.md
+++ b/website/docs/ArgParser-Replacement.md
@@ -6,10 +6,10 @@ from the command line or from setting defaults within the `@spock` decorated cla
 ### Automatic Command-Line Argument Generation
 
 `spock` will automatically generate command line arguments for each parameter, unless the `no_cmd_line=True` flag is 
-passed to the `ConfigArgBuilder`. Let's create a simple example to demonstrate:
+passed to the `SpockBuilder`. Let's create a simple example to demonstrate:
 
 ```python
-from spock.config import spock
+from spock import spock
 from typing import Optional
 
 @spock

--- a/website/docs/Quick-Start.md
+++ b/website/docs/Quick-Start.md
@@ -23,8 +23,8 @@ parameters with supported argument types from the `typing` library. Lastly, we w
 docstrings to provide command line `--help` information.
 
 ```python
-from spock.builder import ConfigArgBuilder
-from spock.config import spock
+from spock import SpockBuilder
+from spock import spock
 from typing import List
 
 @spock
@@ -65,7 +65,7 @@ def add_by_parameter(multiply_param, list_vals, add_param, tf_round):
     return val_sum
 ```
 
-Now, we build out the parameter objects by passing in the `spock` objects (as `*args`) to the `ConfigArgBuilder` 
+Now, we build out the parameter objects by passing in the `spock` objects (as `*args`) to the `SpockBuilder` 
 and chain call the `generate` method. The returned namespace object contains the defined classes named with the given
 `spock` class name. We then can pass the whole object to our first function or specific parameters to our
 second function.
@@ -73,7 +73,7 @@ second function.
 ```python
 def main():
     # Chain the generate function to the class call
-    config = ConfigArgBuilder(BasicConfig, desc='Quick start example').generate()
+    config = SpockBuilder(BasicConfig, desc='Quick start example').generate()
     # One can now access the Spock config object by class name with the returned namespace
     print(config.BasicConfig.parameter)
     # And pass the namespace to our first function

--- a/website/docs/addons/S3.md
+++ b/website/docs/addons/S3.md
@@ -2,7 +2,7 @@
 
 When installed with the S3 addon `spock` will attempt to identify S3 URI(s) (e.g. `s3://<bucket-name>/<key>`) and handle 
 them automatically. The user only needs to provide an active `boto3.session.Session` to an `S3Config` object and pass
-it to the `ConfigArgBuilder`.
+it to the `SpockBuilder`.
 
 
 ### Installing
@@ -47,12 +47,12 @@ session = boto3.Session(
 ### Using the S3Config Object
 
 As an example let's create a basic `@spock` decorated class, instantiate a `S3Config` object from `spock.addons.s3` with
-the `boto3.session.Session` we created above, and pass it to the `ConfigArgBuilder`.
+the `boto3.session.Session` we created above, and pass it to the `SpockBuilder`.
 
 ```python
 from spock.addons.s3 import S3Config
-from spock.builder import ConfigArgBuilder
-from spock.config import spock
+from spock import SpockBuilder
+from spock import spock
 from typing import List
 
 @spock
@@ -76,9 +76,9 @@ def main():
     s3_config = S3Config(
         session=session
     )
-    # Chain the generate function to the ConfigArgBuilder call
+    # Chain the generate function to the SpockBuilder call
     # Pass in the S3Config object
-    config = ConfigArgBuilder(
+    config = SpockBuilder(
         BasicConfig, 
         desc='S3 example',
         s3_config=s3_config
@@ -94,7 +94,7 @@ in a S3 URI instead:
 $ python simple.py -c s3://my-bucket/path/to/file/config.yaml
 ```
 
-With a `S3Config` object passed into the `ConfigArgBuilder` the S3 URI will automatically be handled by `spock`.
+With a `S3Config` object passed into the `SpockBuilder` the S3 URI will automatically be handled by `spock`.
 
 ### Saving to a S3 URI
 
@@ -107,16 +107,16 @@ def main():
     s3_config = S3Config(
         session=session
     )
-    # Chain the generate function to the ConfigArgBuilder call
+    # Chain the generate function to the SpockBuilder call
     # Pass in the S3Config object
-    config = ConfigArgBuilder(
+    config = SpockBuilder(
         BasicConfig, 
         desc='S3 example',
         s3_config=s3_config
     ).save(user_specified_path="s3://my-bucket/path/to/file/").generate()
 ```
 
-With a `S3Config` object passed into the `ConfigArgBuilder` the S3 URI will automatically be handled by `spock`.
+With a `S3Config` object passed into the `SpockBuilder` the S3 URI will automatically be handled by `spock`.
 
 ### S3Transfer ExtraArgs
 

--- a/website/docs/addons/tuner/Ax.md
+++ b/website/docs/addons/tuner/Ax.md
@@ -14,33 +14,46 @@ posterity let's add some fixed parameters (those that are not part of hyper-para
 elsewhere in our code. 
 
 ```python
-from spock.config import spock
+from spock import spock
+
+from spock.addons.tune import (
+    ChoiceHyperParameter,
+    RangeHyperParameter,
+    spockTuner,
+)
 
 @spock
 class BasicParams:
     n_trials: int
     max_iter: int
+
+
+@spockTuner
+class LogisticRegressionHP:
+    c: RangeHyperParameter
+    solver: ChoiceHyperParameter
 ```
 
 Now we need to tell `spock` that we intend on doing hyper-parameter tuning and which backend we would like to use. We
-do this by calling the `tuner` method on the `ConfigArgBuilder` object passing in a configuration object for the
+do this by calling the `tuner` method on the `SpockBuilder` object passing in a configuration object for the
 backend of choice (just like in basic functionality this is a chained command, thus the builder object will still be 
 returned). For Ax one uses `AxTunerConfig`. This config mirrors all options that would be passed into 
 the `AxClient` constructor and the `AxClient.create_experiment`function call so that `spock` can setup the 
-Service API. (Note: The `@spockTuner`decorated classes are passed to the `ConfigArgBuilder` in the exact same 
+Service API. (Note: The `@spockTuner`decorated classes are passed to the `SpockBuilder` in the exact same 
 way as basic `@spock`decorated classes.)
 
 ```python
+from spock import SpockBuilder
 from spock.addons.tune import AxTunerConfig
 
 # Ax config -- this will internally spawn the AxClient service API style which will be returned
-# by accessing the tuner_status property on the ConfigArgBuilder object -- note here that we need to define the
+# by accessing the tuner_status property on the SpockBuilder object -- note here that we need to define the
 # objective name that the client will expect to be within the data dictionary when completing trials 
 ax_config = AxTunerConfig(objective_name="accuracy", minimize=False)
 
 # Use the builder to setup
 # Call tuner to indicate that we are going to do some HP tuning -- passing in an ax study object
-attrs_obj = ConfigArgBuilder(
+attrs_obj = SpockBuilder(
     LogisticRegressionHP,
     BasicParams,
     desc="Example Logistic Regression Hyper-Parameter Tuning -- Ax Backend",

--- a/website/docs/addons/tuner/Basics.md
+++ b/website/docs/addons/tuner/Basics.md
@@ -56,11 +56,13 @@ X_train, X_valid, y_train, y_valid = train_test_split(X, y)
 
 ```
 
-The `@spockTuner` decorated classes are passed to the `ConfigArgBuilder` in the exact same way as basic `@spock` 
+The `@spockTuner` decorated classes are passed to the `CSpockBuilder` in the exact same way as basic `@spock` 
 decorated classes. This returns a `spock` builder object which can be used to call different methods.
 
 ```python
-attrs_obj = ConfigArgBuilder(
+from spock import SpockBuilder
+
+attrs_obj = SpockBuilder(
     LogisticRegressionHP,
     desc="Example Logistic Regression Hyper-Parameter Tuning",
 )

--- a/website/docs/addons/tuner/Optuna.md
+++ b/website/docs/addons/tuner/Optuna.md
@@ -14,34 +14,47 @@ posterity let's add some fixed parameters (those that are not part of hyper-para
 elsewhere in our code. 
 
 ```python
-from spock.config import spock
+from spock import spock
+
+from spock.addons.tune import (
+    ChoiceHyperParameter,
+    RangeHyperParameter,
+    spockTuner,
+)
 
 @spock
 class BasicParams:
     n_trials: int
     max_iter: int
+
+
+@spockTuner
+class LogisticRegressionHP:
+    c: RangeHyperParameter
+    solver: ChoiceHyperParameter
 ```
 
 Now we need to tell `spock` that we intend on doing hyper-parameter tuning and which backend we would like to use. We
-do this by calling the `tuner` method on the `ConfigArgBuilder` object passing in a configuration object for the
+do this by calling the `tuner` method on the `SpockBuilder` object passing in a configuration object for the
 backend of choice (just like in basic functionality this is a chained command, thus the builder object will still be 
 returned). For Optuna one uses `OptunaTunerConfig`. This config mirrors all options that would be passed into 
 the `optuna.study.create_study` function call so that `spock` can setup the define-and-run API. (Note: The `@spockTuner` 
-decorated classes are passed to the `ConfigArgBuilder` in the exact same way as basic `@spock` 
+decorated classes are passed to the `SpockBuilder` in the exact same way as basic `@spock` 
 decorated classes.)
 
 ```python
+from spock import SpockBuilder
 from spock.addons.tune import OptunaTunerConfig
 
 # Optuna config -- this will internally configure the study object for the define-and-run style which will be returned
-# by accessing the tuner_status property on the ConfigArgBuilder object
+# by accessing the tuner_status property on the SpockBuilder object
 optuna_config = OptunaTunerConfig(
     study_name="Iris Logistic Regression", direction="maximize"
 )
 
 # Use the builder to setup
 # Call tuner to indicate that we are going to do some HP tuning -- passing in an optuna study object
-attrs_obj = ConfigArgBuilder(
+attrs_obj = SpockBuilder(
     LogisticRegressionHP,
     BasicParams,
     desc="Example Logistic Regression Hyper-Parameter Tuning -- Optuna Backend",

--- a/website/docs/addons/tuner/Saving.md
+++ b/website/docs/addons/tuner/Saving.md
@@ -14,7 +14,7 @@ For instance in `tune.py`:
 ```python
 
 # Chain the .save call which will dump the hyper-parameter definitions to the configuration file
-attrs_obj = ConfigArgBuilder(
+attrs_obj = SpockBuilder(
         LogisticRegressionHP,
         BasicParams,
         desc="Example Logistic Regression Hyper-Parameter Tuning",

--- a/website/docs/advanced_features/Command-Line-Overrides.md
+++ b/website/docs/advanced_features/Command-Line-Overrides.md
@@ -7,13 +7,12 @@ normally require use of another argparser.
 ### Automatic Command-Line Argument Generation
 
 `spock` will automatically generate command line arguments for each parameter, unless the `no_cmd_line=True` flag is 
-passed to the `ConfigArgBuilder`. Let's look at two of the `@spock` decorated classes from the `tutorial.py` file to 
+passed to the `SpockBuilder`. Let's look at two of the `@spock` decorated classes from the `tutorial.py` file to 
 illustrate how this works in practice:
 
 ```python
 from enum import Enum
-from spock.args import SavePath
-from spock.config import spock
+from spock import spock
 from typing import List
 from typing import Optional
 from typing import Tuple
@@ -56,8 +55,7 @@ Using the automatically generated command-line arguments, let's override a few v
 
 ```python
 from enum import Enum
-from spock.args import SavePath
-from spock.config import spock
+from spock import spock
 from typing import List
 from typing import Optional
 from typing import Tuple
@@ -76,7 +74,6 @@ class Optimizer(Enum):
 
 @spock
 class ModelConfig:
-    save_path: SavePath
     n_features: int
     dropout: Optional[List[float]]
     hidden_sizes: Tuple[int, int, int] = (32, 32, 32)
@@ -179,7 +176,7 @@ For `List` of Repeated `@spock` Classes the syntax is slightly different to allo
 Given the below example code:
 
 ```python
-from spock.config import spock
+from spock import spock
 from typing import List
 
 

--- a/website/docs/advanced_features/Defaults.md
+++ b/website/docs/advanced_features/Defaults.md
@@ -16,8 +16,7 @@ Let's modify the definition in: `tutorial.py`
 
 ```python
 from enum import Enum
-from spock.args import SavePath
-from spock.config import spock
+from spock import spock
 from typing import List
 from typing import Optional
 from typing import Tuple
@@ -30,7 +29,6 @@ class Activation(Enum):
 
 @spock
 class ModelConfig:
-    save_path: SavePath
     lr: float = 0.01
     n_features: int
     dropout: List[float]

--- a/website/docs/advanced_features/Inheritance.md
+++ b/website/docs/advanced_features/Inheritance.md
@@ -16,8 +16,7 @@ Editing our definition in: `tutorial.py`
 
 ```python
 from enum import Enum
-from spock.args import SavePath
-from spock.config import spock
+from spock import spock
 from typing import List
 from typing import Optional
 from typing import Tuple
@@ -35,7 +34,6 @@ class Optimizer(Enum):
 
 @spock
 class ModelConfig:
-    save_path: SavePath
     n_features: int
     dropout: Optional[List[float]]
     hidden_sizes: Tuple[int, int, int] = (32, 32, 32)
@@ -129,7 +127,7 @@ def main():
     # A simple description
     description = 'spock Advanced Tutorial'
     # Build out the parser by passing in Spock config objects as *args after description
-    config = ConfigArgBuilder(ModelConfig, DataConfig, SGDConfig, desc=description).generate()
+    config = SpockBuilder(ModelConfig, DataConfig, SGDConfig, desc=description).generate()
     # Instantiate our neural net using
     basic_nn = BasicNet(model_config=config.ModelConfig)
     # Make some random data (BxH): H has dim of features in

--- a/website/docs/advanced_features/Keyword-Configs.md
+++ b/website/docs/advanced_features/Keyword-Configs.md
@@ -6,7 +6,7 @@ with keyword arguments.
 ### Specifying The Config Keyword Argument
 
 Let's pass in the `yaml` configuration file via the config keyword argument instead of at the command line. Simply
-add the `config` keyword argument to the `ConfigArgBuilder`. Note: This is not the recommended best practice as it
+add the `config` keyword argument to the `SpockBuilder`. Note: This is not the recommended best practice as it
 creates a dependency between code and configuration files. Please use the `-c` command line argument whenever possible.
 The `config` keyword arg should be used *ONLY* when necessary.
 
@@ -19,7 +19,7 @@ def main():
     # A simple description
     description = 'spock Advanced Tutorial'
     # Build out the parser by passing in Spock config objects as *args after description
-    config = ConfigArgBuilder(ModelConfig, DataConfig, SGDConfig, desc=description, config=['./tutorial.yaml']).generate()
+    config = SpockBuilder(ModelConfig, DataConfig, SGDConfig, desc=description, config=['./tutorial.yaml']).generate()
     # Instantiate our neural net using
     basic_nn = BasicNet(model_config=config.ModelConfig)
     # Make some random data (BxH): H has dim of features in
@@ -51,13 +51,13 @@ called and will clash with `spock`. Therefore we need to pass the configuration 
 argument and deactivate the command line argument.
 
 For instance, we create a route for our basic neural network (shown below). We add the `no_cmd_line=True` flag to the 
-`ConfigArgBuilder` to prevent `spock` from references command line arguments:
+`SpockBuilder` to prevent `spock` from references command line arguments:
 
 ```python
 @api.post("/inference/",  status_code=201)
 def create_job(*, data: schemata.Inference):
     # Build out the parser by passing in Spock config objects as *args after description
-    config = ConfigArgBuilder(ModelConfig, DataConfig, SGDConfig, desc=description, config=['./tutorial.yaml'], 
+    config = SpockBuilder(ModelConfig, DataConfig, SGDConfig, desc=description, config=['./tutorial.yaml'], 
                               no_cmd_line=True).generate()
     # Let's assume we have a model loading function based on our params
     basic_nn = LoadBasicNet(model_config=config.ModelConfig)

--- a/website/docs/advanced_features/Lazy-Features.md
+++ b/website/docs/advanced_features/Lazy-Features.md
@@ -1,0 +1,73 @@
+# Lazy Evaluation
+
+`spock` supports lazy evaluation for both dependencies between classes and class inheritance.
+
+### Lazy Class Dependencies
+When we create a new `spock` class that depends on another `spock` class we can be 'lazy' and pass only the top-level 
+class(es) to the `SpockBuilder` instead of all the dependent classes. This tends to make your code much less verbose 
+when there are many `@spock` decorated classes. We do this by setting the `lazy` flag to `True` 
+within the `SpockBuilder`. This will tell spock to look for any missing references to `@spock` decorated classes
+within `sys.modules["spock"].backend.config` and add them to the underlying list of classes within graph construction.
+For instance, 
+
+```python
+from spock import spock
+from spock import SpockBuilder
+
+@spock
+class NestedStuffDefault:
+    away: str = "arsenal"
+    goals: int = 0
+
+
+@spock
+class Maybe:
+    r: int = 4
+    t: float = 1.9
+    nested_no_conf_def: NestedStuffDefault = NestedStuffDefault
+
+
+# Set lazy to True to make sure spock lazily finds @spock decorated classes 
+# Not we only pass the Maybe class here instead of both Maybe and NestedStuffDefault
+config = SpockBuilder(Maybe, desc='Lazy Example', lazy=True).generate()
+```
+
+The above is equivalent to passing both `Maybe` and `NestedStuffDefault` to the `SpockBuilder`.
+
+### Lazy Class Inheritance
+
+When we create a new `spock` class that inherits from another `spock` class we can be 'lazy' and leave off the
+`@spock` decorator for any parent classes. We do this by setting the `dynamic` flag within the `@spock` decorator to
+`True`. With this flag, `spock` will traverse the MRO and automatically cast parent classes to the equivalent of a 
+`@spock` decorated class. With lazy inheritance you only need to pass the child class to the `SpockBuilder` instead of
+all parents and children. Additionally, set the `lazy` flag to `True` within the `SpockBuilder` to lazily find and 
+return the parent classes to the generated `Spockspace`. For instance:
+
+```python
+from spock import spock
+from spock import SpockBuilder
+from typing import Optional
+
+class OptimizerConfig:
+    lr: float = 0.01
+    n_epochs: int = 2
+    grad_clip: Optional[float]
+
+
+class DataConfig:
+    batch_size: int = 2
+
+
+# Set dynamic=True to allow for lazy inheritance
+@spock(dynamic=True)
+class SGDConfig(OptimizerConfig, DataConfig):
+    weight_decay: float
+    momentum: float
+    nesterov: bool
+
+# Set lazy to True to make sure the parent classes are returned from the generate call
+config = SpockBuilder(SGDConfig, desc='Lazy Example', lazy=True).generate()
+```
+
+The above is equivalent to decorating each class with the `@spock` decorator and additionally passing `DataConfig` and
+`OptimizerConfig` to the `SpockBuilder`.

--- a/website/docs/advanced_features/Local-Definitions.md
+++ b/website/docs/advanced_features/Local-Definitions.md
@@ -12,8 +12,7 @@ Editing our definition in: `tutorial.py`
 
 ```python
 from enum import Enum
-from spock.args import SavePath
-from spock.config import spock
+from spock import spock
 from typing import List
 from typing import Optional
 from typing import Tuple
@@ -32,7 +31,6 @@ class Optimizer(Enum):
 
 @spock
 class ModelConfig:
-    save_path: SavePath
     n_features: int
     dropout: Optional[List[float]]
     hidden_sizes: Tuple[int, int, int] = (32, 32, 32)

--- a/website/docs/advanced_features/Optional-Parameters.md
+++ b/website/docs/advanced_features/Optional-Parameters.md
@@ -16,8 +16,7 @@ definition in: `tutorial.py`
 
 ```python
 from enum import Enum
-from spock.args import SavePath
-from spock.config import spock
+from spock import spock
 from typing import List
 from typing import Optional
 from typing import Tuple
@@ -30,7 +29,6 @@ class Activation(Enum):
 
 @spock
 class ModelConfig:
-    save_path: SavePath
     lr: float = 0.01
     n_features: int
     dropout: Optional[List[float]]

--- a/website/docs/advanced_features/Parameter-Groups.md
+++ b/website/docs/advanced_features/Parameter-Groups.md
@@ -14,8 +14,7 @@ Editing our definition in: `tutorial.py`
 
 ```python
 from enum import Enum
-from spock.args import SavePath
-from spock.config import spock
+from spock import spock
 from typing import List
 from typing import Optional
 from typing import Tuple
@@ -33,7 +32,6 @@ class Optimizer(Enum):
 
 @spock
 class ModelConfig:
-    save_path: SavePath
     n_features: int
     dropout: Optional[List[float]]
     hidden_sizes: Tuple[int, int, int] = (32, 32, 32)
@@ -56,16 +54,16 @@ class OptimizerConfig:
 ```
 
 Now we have three separate `spock` classes that we need to generate the namespace object from. Simply add the new 
-classes to `*args` in the `ConfigArgBuilder`. Editing `tutorial.py`:
+classes to `*args` in the `SpockBuilder`. Editing `tutorial.py`:
 
 ```python
-from spock.builder import ConfigArgBuilder
+from spock.builder import SpockBuilder
 
 def main():
     # A simple description
     description = 'spock Advanced Tutorial'
     # Build out the parser by passing in Spock config objects as *args after description
-    config = ConfigArgBuilder(ModelConfig, DataConfig, OptimizerConfig, desc=description).generate()
+    config = SpockBuilder(ModelConfig, DataConfig, OptimizerConfig, desc=description).generate()
     # One can now access the Spock config object by class name with the returned namespace
     # For instance...
     print(config.ModelConfig)
@@ -131,7 +129,7 @@ def main():
     # A simple description
     description = 'spock Advanced Tutorial'
     # Build out the parser by passing in Spock config objects as *args after description
-    config = ConfigArgBuilder(ModelConfig, DataConfig, OptimizerConfig, desc=description).generate()
+    config = SpockBuilder(ModelConfig, DataConfig, OptimizerConfig, desc=description).generate()
     # Instantiate our neural net using
     basic_nn = BasicNet(model_config=config.ModelConfig)
     # Make some random data (BxH): H has dim of features in

--- a/website/docs/basics/Building.md
+++ b/website/docs/basics/Building.md
@@ -29,18 +29,18 @@ class ModelConfig:
     activation: Activation
 ```
 
-To generate the namespace object, import the `ConfigArgBuilder` class, pass in your `@spock` classes as `*args`, 
+To generate the namespace object, import the `SpockBuilder` class, pass in your `@spock` classes as `*args`, 
 add an optional description, and then chain call the `generate()` method. Each `spock` class is defined in the 
 namespace object given by the class name.
 
 ```python
-from spock.builder import ConfigArgBuilder
+from spock import SpockBuilder
 
 def main():
     # A simple description
     description = 'spock Tutorial'
     # Build out the parser by passing in Spock config objects as *args after description
-    config = ConfigArgBuilder(ModelConfig, desc=description).generate()
+    config = SpockBuilder(ModelConfig, desc=description).generate()
     # One can now access the Spock config object by class name with the returned namespace
     # For instance...
     print(config.ModelConfig)
@@ -65,7 +65,7 @@ def main():
     # A simple description
     description = 'spock Tutorial'
     # Build out the parser by passing in Spock config objects as *args after description
-    config = ConfigArgBuilder(ModelConfig, desc=description).generate()
+    config = SpockBuilder(ModelConfig, desc=description).generate()
     # Instantiate our neural net using
     basic_nn = BasicNet(model_config=config.ModelConfig)
     # Make some random data (BxH): H has dim of features in

--- a/website/docs/basics/Define.md
+++ b/website/docs/basics/Define.md
@@ -46,7 +46,7 @@ your `spock` class just like other types.
 
 ```python
 from enum import Enum
-from spock.config import spock
+from spock import spock
 from typing import List
 from typing import Tuple
 
@@ -74,7 +74,6 @@ for help information for each parameter. Modifying the above code to include hel
 
 ```python
 from enum import Enum
-from spock.args import SavePath
 from spock.config import spock
 from typing import List
 from typing import Tuple
@@ -97,13 +96,11 @@ class ModelConfig:
     """Main model configuration for a basic neural net
 
     Attributes:
-        save_path: spock special keyword -- path to write out spock config state
         n_features: number of data features
         dropout: dropout rate for each layer
         hidden_sizes: hidden size for each layer
         activation: choice from the Activation enum of the activation function to use
     """
-    save_path: SavePath
     n_features: int
     dropout: List[float]
     hidden_sizes: Tuple[int, int, int]
@@ -126,7 +123,6 @@ spock Basic Tutorial
 configuration(s):
 
   ModelConfig (Main model configuration for a basic neural net)
-    save_path       Optional[SavePath]      spock special keyword -- path to write out spock config state (default: None)
     n_features      int                     number of data features 
     dropout         List[float]             dropout rate for each layer 
     hidden_sizes    Tuple[int, int, int]    hidden size for each layer 

--- a/website/docs/basics/Saving.md
+++ b/website/docs/basics/Saving.md
@@ -1,7 +1,7 @@
 # Saving
 
 The current configuration of running python code can be saved to file by chaining the `save()` method before 
-the `generate()` call to the `ConfigArgBuilder` class. `spock` supports two different ways to specify the write path 
+the `generate()` call to the `SpockBuilder` class. `spock` supports two different ways to specify the write path 
 and supports multiple output formats (YAML, TOML, or JSON -- via the `file_extension` keyword argument). Most 
 importantly, the saved markdown file can be used as the configuration input to reproduce prior runtime configurations.
 
@@ -72,7 +72,7 @@ def main():
     # A simple description
     description = 'spock Tutorial'
     # Build out the parser by passing in Spock config objects as *args after description
-    config = ConfigArgBuilder(ModelConfig, desc=description).save(file_extension='.toml').generate()
+    config = SpockBuilder(ModelConfig, desc=description).save(file_extension='.toml').generate()
     # One can now access the Spock config object by class name with the returned namespace
     # For instance...
     print(config.ModelConfig)
@@ -102,7 +102,7 @@ def main():
     # A simple description
     description = 'spock Tutorial'
     # Build out the parser by passing in Spock config objects as *args after description
-    config = ConfigArgBuilder(ModelConfig, desc=description).save(user_specified_path='/tmp').generate()
+    config = SpockBuilder(ModelConfig, desc=description).save(user_specified_path='/tmp').generate()
     # One can now access the Spock config object by class name with the returned namespace
     # For instance...
     print(config.ModelConfig)
@@ -120,7 +120,7 @@ def main():
     # A simple description
     description = 'spock Tutorial'
     # Build out the parser by passing in Spock config objects as *args after description
-    config = ConfigArgBuilder(ModelConfig, desc=description).save(create_save_path=True).generate()
+    config = SpockBuilder(ModelConfig, desc=description).save(create_save_path=True).generate()
     # One can now access the Spock config object by class name with the returned namespace
     # For instance...
     print(config.ModelConfig)
@@ -139,7 +139,7 @@ def main():
     # A simple description
     description = 'spock Tutorial'
     # Build out the parser by passing in Spock config objects as *args after description
-    config = ConfigArgBuilder(ModelConfig, desc=description).save(file_name='cool_name_here').generate()
+    config = CSpockBuilder(ModelConfig, desc=description).save(file_name='cool_name_here').generate()
     # One can now access the Spock config object by class name with the returned namespace
     # For instance...
     print(config.ModelConfig)

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -96,6 +96,11 @@ module.exports = {
                 },
                 {
                     type: 'doc',
+                    label: 'Lazy Dependencies',
+                    id: "advanced_features/Lazy-Features"
+                },
+                {
+                    type: 'doc',
                     label: 'Local Definitions',
                     id: 'advanced_features/Local-Definitions'
                 },


### PR DESCRIPTION
## What does this PR do?
* adds some stubs to the underlying decorator that should help with type hinting in VSCode (via pylance/pyright). 

* changed packaging to reflect the stubs and partial type info

* Additional interfaces to spock that make more sense: 

ConfigArgBuilder --> SpockBuilder -- Can now be imported from top-level
@spock decorator now importable from the top-level

```python
from spock import spock
from spock import SpockBuilder
```

Lazy Evaluation

* the @spock decorator now has a boolean flag  that allows inherited classes to not be @spock decorated -- will automatically cast parent classes to a spock class by traversing the MRO
* 
* the ConfigArgBuilder now takes a  keyword argument that will attempt to lazily handle dependencies between @spock decorated classes thus preventing the need for every @spock decorated classes to be passed into *args within the  method

## Checklist
  - [x] Did you adhere to [PEP-8](https://www.python.org/dev/peps/pep-0008/) standards?
  - [x] Did you run black and isort prior to submitting your PR? 
  - [x] Does your PR pass all existing unit tests?
  - [x] Did you add associated unit tests for any additional functionality?
  - [x] Did you provide documentation ([Google Docstring format](https://google.github.io/styleguide/pyguide.html)) whenever possible, even for simple functions or classes?