### PR TITLE
Adds support for typing.Dict types

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ See [Releases](https://github.com/fidelity/spock/releases) for more information.
 
 <details>
 
-#### March 15th, 2022
+#### March 17th, 2022
 * Added support for `typing.Callable` types (includes advanced types such as `List[List[Callable]]`)
 * Added support for `typing.Dict` types with type checking for types of both keys and values (includes advanced types
 such as `Dict[str, Tuple[Callable, Callable]]`)

--- a/README.md
+++ b/README.md
@@ -101,8 +101,10 @@ See [Releases](https://github.com/fidelity/spock/releases) for more information.
 
 <details>
 
-#### March 11th, 2022
-* Added support for simple `typing.Callable` types (WIP: advanced versions)
+#### March 15th, 2022
+* Added support for `typing.Callable` types (includes advanced types such as `List[List[Callable]]`)
+* Added support for `typing.Dict` types with type checking for types of both keys and values (includes advanced types
+such as `Dict[str, Tuple[Callable, Callable]]`)
 * Added support for post init hooks that allow for validation on parameters defined within `@spock` decorated classes. 
 Additionally, added some common validation check to utils (within, greater than, less than, etc.)
 * Updated unit tests to support Python 3.10

--- a/requirements/DEV_REQUIREMENTS.txt
+++ b/requirements/DEV_REQUIREMENTS.txt
@@ -1,7 +1,7 @@
 black~=22.1 ; python_version >= '3.7'
 black~=21.4b0 ; python_version == '3.6'
 coveralls~=3.3
-coverage~=6.1
+coverage[toml]~=6.1
 isort~=5.10
 moto~=3.0
 pydoc-markdown~=4.3 ; python_version >= '3.7'

--- a/requirements/DEV_REQUIREMENTS.txt
+++ b/requirements/DEV_REQUIREMENTS.txt
@@ -4,7 +4,7 @@ coveralls~=3.3
 coverage[toml]~=6.1
 isort~=5.10
 moto~=3.0
-pydoc-markdown~=4.3 ; python_version >= '3.7'
+pydoc-markdown~=4.3, < 4.6.* ; python_version >= '3.7'
 pydoc-markdown~=3.13 ; python_version == '3.6'
 pytest~=7.0
 pytest-cov~=3.0

--- a/spock/args.py
+++ b/spock/args.py
@@ -11,6 +11,8 @@ from _warnings import warn
 from spock.exceptions import _SpockDuplicateArgumentError
 from spock.graph import Graph
 
+from typing import Dict, Iterable, Any
+
 
 class SpockArguments:
     """Class that handles mapping the read parameter dictionary to general or class level arguments
@@ -20,7 +22,7 @@ class SpockArguments:
 
     """
 
-    def __init__(self, arguments: dict, config_dag: Graph):
+    def __init__(self, arguments: Dict, config_dag: Graph):
         """Init call for SpockArguments class
 
         Handles creating a clean arguments dictionary that can be cleanly mapped to spock classes
@@ -39,7 +41,7 @@ class SpockArguments:
             general_arguments, attribute_name_to_config_name_mapping
         )
 
-    def __getitem__(self, key: str):
+    def __getitem__(self, key: str) -> Any:
         """Gets value from the _arguments dictionary
 
         Args:
@@ -51,7 +53,7 @@ class SpockArguments:
         """
         return self._arguments[key]
 
-    def __iter__(self):
+    def __iter__(self) -> Iterable[str]:
         """Returns the next value of the keys within the _arguments dictionary
 
         Returns:
@@ -77,7 +79,7 @@ class SpockArguments:
         return self._arguments.values()
 
     @staticmethod
-    def _get_general_arguments(arguments: dict, config_dag: Graph):
+    def _get_general_arguments(arguments: Dict, config_dag: Graph) -> Dict:
         """Creates a dictionary of config file parameters that are defined at the general level (not class specific)
 
         Args:
@@ -96,8 +98,8 @@ class SpockArguments:
         }
 
     def _attribute_name_to_config_name_mapping(
-        self, config_dag: Graph, general_arguments: dict
-    ):
+        self, config_dag: Graph, general_arguments: Dict
+    ) -> Dict:
         """Returns a mapping of names to spock config class parameter names
 
         Args:
@@ -125,8 +127,8 @@ class SpockArguments:
 
     @staticmethod
     def _is_duplicated_key(
-        attribute_name_to_config_name_mapping: dict, attr_name: str, config_name: str
-    ):
+        attribute_name_to_config_name_mapping: Dict, attr_name: str, config_name: str
+    ) -> bool:
         """Checks if a duplicated key exists in multiple classes
 
         Args:
@@ -144,8 +146,8 @@ class SpockArguments:
         )
 
     def _assign_general_arguments_to_config(
-        self, general_arguments: dict, attribute_name_to_config_name_mapping: dict
-    ):
+        self, general_arguments: Dict, attribute_name_to_config_name_mapping: Dict
+    ) -> None:
         """Assigns the values from general definitions to values within specific classes if the specific definition
         doesn't exist
 
@@ -172,7 +174,7 @@ class SpockArguments:
                 self._arguments[config_name] = {arg: value}
 
     @staticmethod
-    def _clean_arguments(arguments: dict, general_arguments: dict):
+    def _clean_arguments(arguments: Dict, general_arguments: Dict) -> Dict:
         """Sets up a clean dictionary for those not in the general dictionary
 
         Args:

--- a/spock/args.py
+++ b/spock/args.py
@@ -6,12 +6,12 @@
 """Handles mapping config arguments to a payload with both general and class specific sets"""
 
 
+from typing import Any, Dict, Iterable
+
 from _warnings import warn
 
 from spock.exceptions import _SpockDuplicateArgumentError
 from spock.graph import Graph
-
-from typing import Dict, Iterable, Any
 
 
 class SpockArguments:

--- a/spock/backend/builder.py
+++ b/spock/backend/builder.py
@@ -4,11 +4,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """Handles the building/saving of the configurations from the Spock config classes"""
-import sys
-import typing
+import argparse
 from abc import ABC, abstractmethod
 from enum import EnumMeta
-from typing import List
+from typing import List, Dict
 
 import attr
 
@@ -18,7 +17,7 @@ from spock.backend.help import attrs_help
 from spock.backend.spaces import BuilderSpace
 from spock.backend.wrappers import Spockspace
 from spock.graph import Graph
-from spock.utils import _SpockVariadicGenericAlias, make_argument
+from spock.utils import _SpockVariadicGenericAlias, make_argument, _C, _T
 
 
 class BaseBuilder(ABC):  # pylint: disable=too-few-public-methods
@@ -75,7 +74,7 @@ class BaseBuilder(ABC):  # pylint: disable=too-few-public-methods
 
     @staticmethod
     @abstractmethod
-    def _make_group_override_parser(parser, class_obj, class_name):
+    def _make_group_override_parser(parser: argparse.ArgumentParser, class_obj: _C, class_name: str) -> argparse.ArgumentParser:
         """Makes a name specific override parser for a given class obj
 
         Takes a class object of the backend and adds a new argument group with argument names given with name
@@ -91,7 +90,7 @@ class BaseBuilder(ABC):  # pylint: disable=too-few-public-methods
 
         """
 
-    def handle_help_info(self):
+    def handle_help_info(self) -> None:
         """Handles walking through classes to get help info
 
         For each class this function will search __doc__ and attempt to pull out help information for both the class
@@ -108,7 +107,7 @@ class BaseBuilder(ABC):  # pylint: disable=too-few-public-methods
             max_indent=self._max_indent,
         )
 
-    def generate(self, dict_args):
+    def generate(self, dict_args: Dict) -> Spockspace:
         """Method to auto-generate the actual class instances from the generated args
 
         Based on the generated arguments groups and the args read in from the config file(s)
@@ -123,7 +122,7 @@ class BaseBuilder(ABC):  # pylint: disable=too-few-public-methods
         spock_space_kwargs = self.resolve_spock_space_kwargs(self._graph, dict_args)
         return Spockspace(**spock_space_kwargs)
 
-    def resolve_spock_space_kwargs(self, graph: Graph, dict_args: dict) -> dict:
+    def resolve_spock_space_kwargs(self, graph: Graph, dict_args: Dict) -> Dict:
         """Build the dictionary that will define the spock space.
 
         Args:
@@ -152,7 +151,7 @@ class BaseBuilder(ABC):  # pylint: disable=too-few-public-methods
 
         return spock_space
 
-    def build_override_parsers(self, parser):
+    def build_override_parsers(self, parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
         """Creates parsers for command-line overrides
 
         Builds the basic command line parser for configs and help then iterates through each attr instance to make
@@ -172,7 +171,7 @@ class BaseBuilder(ABC):  # pylint: disable=too-few-public-methods
             )
         return parser
 
-    def _extract_other_types(self, typed, module_name):
+    def _extract_other_types(self, typed: _T, module_name: str) -> List:
         """Takes a high level type and recursively extracts any enum or class types
 
         Args:
@@ -237,7 +236,7 @@ class AttrBuilder(BaseBuilder):
         super().__init__(*args, module_name="spock.backend.config", **kwargs)
 
     @staticmethod
-    def _make_group_override_parser(parser, class_obj, class_name):
+    def _make_group_override_parser(parser: argparse.ArgumentParser, class_obj: _C, class_name: str) -> argparse.ArgumentParser:
         """Makes a name specific override parser for a given class obj
 
         Takes a class object of the backend and adds a new argument group with argument names given with name

--- a/spock/backend/builder.py
+++ b/spock/backend/builder.py
@@ -7,7 +7,7 @@
 import argparse
 from abc import ABC, abstractmethod
 from enum import EnumMeta
-from typing import List, Dict
+from typing import Dict, List
 
 import attr
 
@@ -17,7 +17,7 @@ from spock.backend.help import attrs_help
 from spock.backend.spaces import BuilderSpace
 from spock.backend.wrappers import Spockspace
 from spock.graph import Graph
-from spock.utils import _SpockVariadicGenericAlias, make_argument, _C, _T
+from spock.utils import _C, _T, _SpockVariadicGenericAlias, make_argument
 
 
 class BaseBuilder(ABC):  # pylint: disable=too-few-public-methods
@@ -74,7 +74,9 @@ class BaseBuilder(ABC):  # pylint: disable=too-few-public-methods
 
     @staticmethod
     @abstractmethod
-    def _make_group_override_parser(parser: argparse.ArgumentParser, class_obj: _C, class_name: str) -> argparse.ArgumentParser:
+    def _make_group_override_parser(
+        parser: argparse.ArgumentParser, class_obj: _C, class_name: str
+    ) -> argparse.ArgumentParser:
         """Makes a name specific override parser for a given class obj
 
         Takes a class object of the backend and adds a new argument group with argument names given with name
@@ -151,7 +153,9 @@ class BaseBuilder(ABC):  # pylint: disable=too-few-public-methods
 
         return spock_space
 
-    def build_override_parsers(self, parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
+    def build_override_parsers(
+        self, parser: argparse.ArgumentParser
+    ) -> argparse.ArgumentParser:
         """Creates parsers for command-line overrides
 
         Builds the basic command line parser for configs and help then iterates through each attr instance to make
@@ -236,7 +240,9 @@ class AttrBuilder(BaseBuilder):
         super().__init__(*args, module_name="spock.backend.config", **kwargs)
 
     @staticmethod
-    def _make_group_override_parser(parser: argparse.ArgumentParser, class_obj: _C, class_name: str) -> argparse.ArgumentParser:
+    def _make_group_override_parser(
+        parser: argparse.ArgumentParser, class_obj: _C, class_name: str
+    ) -> argparse.ArgumentParser:
         """Makes a name specific override parser for a given class obj
 
         Takes a class object of the backend and adds a new argument group with argument names given with name

--- a/spock/backend/field_handlers.py
+++ b/spock/backend/field_handlers.py
@@ -9,21 +9,23 @@ import importlib
 import sys
 from abc import ABC, abstractmethod
 from enum import EnumMeta
-from typing import List, Type
+from typing import Callable, Dict, List, Type, Tuple
 
 from attr import NOTHING, Attribute
 
+from spock.backend.utils import _str_2_callable, _get_name_py_version, _recurse_callables
 from spock.backend.spaces import AttributeSpace, BuilderSpace, ConfigSpace
 from spock.exceptions import (
     _SpockInstantiationError,
-    _SpockNotOptionalError,
-    _SpockValueError,
+    _SpockNotOptionalError
 )
 from spock.utils import (
     _check_iterable,
     _is_spock_instance,
     _is_spock_tune_instance,
     _SpockVariadicGenericAlias,
+    _C,
+    _T
 )
 
 
@@ -354,21 +356,12 @@ class RegisterCallableField(RegisterFieldTemplate):
 
         Returns:
         """
-        # These are always going to be strings... cast just in case
-        str_field = str(
-            builder_space.arguments[attr_space.config_space.name][
+        # These should always be strings
+        str_field = builder_space.arguments[attr_space.config_space.name][
                 attr_space.attribute.name
             ]
-        )
-        module, fn = str_field.rsplit(".", 1)
-        try:
-            call_ref = getattr(importlib.import_module(module), fn)
-            attr_space.field = call_ref
-        except Exception as e:
-            raise _SpockValueError(
-                f"Attempted to import module {module} and callable {fn} however it could not be found on the current "
-                f"python path: {e}"
-            )
+        call_ref = _str_2_callable(str_field)
+        attr_space.field = call_ref
 
     def handle_optional_attribute_type(
         self, attr_space: AttributeSpace, builder_space: BuilderSpace
@@ -390,8 +383,8 @@ class RegisterCallableField(RegisterFieldTemplate):
         )
 
 
-class RegisterListCallableField(RegisterFieldTemplate):
-    """Class that registers callable types
+class RegisterGenericAliasCallableField(RegisterFieldTemplate):
+    """Class that registers Dicts containing callable types
 
     Attributes:
         special_keys: dictionary to check special keys
@@ -403,28 +396,7 @@ class RegisterListCallableField(RegisterFieldTemplate):
 
         Args:
         """
-        super(RegisterListCallableField, self).__init__()
-
-    def _convert(self, val):
-        str_field = str(val)
-        module, fn = str_field.rsplit(".", 1)
-        try:
-            call_ref = getattr(importlib.import_module(module), fn)
-        except Exception as e:
-            raise _SpockValueError(
-                f"Attempted to import module {module} and callable {fn} however it could not be found on the current "
-                f"python path: {e}"
-            )
-        return call_ref
-
-    def _recurse_callables(self, val: List):
-        attr_list = []
-        for sub in val:
-            if isinstance(sub, list) or isinstance(sub, List):
-                attr_list.append(self._recurse_callables(sub))
-            else:
-                attr_list.append(self._convert(sub))
-        return attr_list
+        super(RegisterGenericAliasCallableField, self).__init__()
 
     def handle_attribute_from_config(
         self, attr_space: AttributeSpace, builder_space: BuilderSpace
@@ -437,16 +409,23 @@ class RegisterListCallableField(RegisterFieldTemplate):
 
         Returns:
         """
-        # These are always going to be strings... cast just in case
-        attr_list = []
-        for val in builder_space.arguments[attr_space.config_space.name][
-            attr_space.attribute.name
-        ]:
-            if isinstance(val, list) or isinstance(val, List):
-                attr_list.append(self._recurse_callables(val))
-            else:
-                attr_list.append(self._convert(val))
-        attr_space.field = attr_list
+        typed = attr_space.attribute.metadata["type"]
+        out = None
+        # Handle List Types
+        if _get_name_py_version(typed) == "List" or _get_name_py_version(typed) == "Tuple":
+            out = []
+            for v in builder_space.arguments[attr_space.config_space.name][
+                attr_space.attribute.name
+            ]:
+                out.append(_recurse_callables(v, _str_2_callable))
+        # Handle Dict Types
+        elif _get_name_py_version(typed) == "Dict":
+            out = {}
+            for k, v in builder_space.arguments[attr_space.config_space.name][
+                attr_space.attribute.name
+            ].items():
+                out.update({k: _recurse_callables(v, _str_2_callable)})
+        attr_space.field = out
 
     def handle_optional_attribute_type(
         self, attr_space: AttributeSpace, builder_space: BuilderSpace
@@ -718,20 +697,37 @@ class RegisterSpockCls(RegisterFieldTemplate):
         ] = attr_space.field
 
     @classmethod
-    def _find_list_callables(cls, typed):
+    def _find_callables(cls, typed:  _T):
+        """Attempts to find callables nested in Lists, Tuples, or Dicts
+
+        Args:
+            typed: input type
+
+        Returns:
+            boolean if callables are found
+
+        """
         out = False
-        if hasattr(typed, "__args__") and not isinstance(
-            typed.__args__[0], _SpockVariadicGenericAlias
-        ):
-            out = cls._find_list_callables(typed.__args__[0])
-        elif hasattr(typed, "__args__") and isinstance(
-            typed.__args__[0], _SpockVariadicGenericAlias
-        ):
-            out = True
+        if hasattr(typed, "__args__"):
+            if _get_name_py_version(typed) == "List" or _get_name_py_version(typed) == "Tuple":
+                # Possibly nested Callables
+                if not isinstance(typed.__args__[0], _SpockVariadicGenericAlias):
+                    out = cls._find_callables(typed.__args__[0])
+                # Found callables
+                elif isinstance(typed.__args__[0], _SpockVariadicGenericAlias):
+                    out = True
+            elif _get_name_py_version(typed) == "Dict":
+                key_type, value_type = typed.__args__
+                if not isinstance(value_type, _SpockVariadicGenericAlias):
+                    out = cls._find_callables(value_type)
+                elif isinstance(value_type, _SpockVariadicGenericAlias):
+                    out = True
+            else:
+                raise TypeError(f"Unexpected type of `{str(typed)}` when attempting to handle GenericAlias types")
         return out
 
     @classmethod
-    def recurse_generate(cls, spock_cls, builder_space: BuilderSpace):
+    def recurse_generate(cls, spock_cls: _C, builder_space: BuilderSpace):
         """Call on a spock classes to iterate through the attrs attributes and handle each based on type and optionality
 
         Triggers a recursive call when an attribute refers to another spock classes
@@ -758,10 +754,12 @@ class RegisterSpockCls(RegisterFieldTemplate):
                 (attribute.type is list) or (attribute.type is List)
             ) and _is_spock_instance(attribute.metadata["type"].__args__[0]):
                 handler = RegisterList()
+            # Dict/List of Callables
             elif (
-                (attribute.type is list) or (attribute.type is List)
-            ) and cls._find_list_callables(attribute.metadata["type"]):
-                handler = RegisterListCallableField()
+                (attribute.type is list) or (attribute.type is List) or (attribute.type is dict) or (attribute.type is Dict) or (attribute.type is tuple) or (attribute.type is Tuple)
+            ) and cls._find_callables(attribute.metadata["type"]):
+                # handler = RegisterListCallableField()
+                handler = RegisterGenericAliasCallableField()
             # Enums
             elif isinstance(attribute.type, EnumMeta) and _check_iterable(
                 attribute.type

--- a/spock/backend/handler.py
+++ b/spock/backend/handler.py
@@ -8,6 +8,8 @@
 from abc import ABC
 
 from spock.handlers import JSONHandler, TOMLHandler, YAMLHandler
+from spock.utils import _T
+from typing import Optional
 
 
 class BaseHandler(ABC):
@@ -19,7 +21,7 @@ class BaseHandler(ABC):
 
     """
 
-    def __init__(self, s3_config=None):
+    def __init__(self, s3_config: Optional[_T] = None):
         self._supported_extensions = {
             ".yaml": YAMLHandler,
             ".toml": TOMLHandler,

--- a/spock/backend/handler.py
+++ b/spock/backend/handler.py
@@ -6,10 +6,10 @@
 """Base handler Spock class"""
 
 from abc import ABC
+from typing import Optional
 
 from spock.handlers import JSONHandler, TOMLHandler, YAMLHandler
 from spock.utils import _T
-from typing import Optional
 
 
 class BaseHandler(ABC):

--- a/spock/backend/help.py
+++ b/spock/backend/help.py
@@ -279,7 +279,7 @@ def attrs_help(
     module_name: str,
     extract_fnc: Callable,
     max_indent: int,
-):
+) -> None:
     """Handles walking through a list classes to get help info
 
     For each class this function will search __doc__ and attempt to pull out help information for both the class

--- a/spock/backend/payload.py
+++ b/spock/backend/payload.py
@@ -17,8 +17,11 @@ from spock.backend.utils import (
     deep_update,
     get_attr_fields,
     get_type_fields,
+    flatten_type_dict
 )
-from spock.utils import check_path_s3
+from spock.utils import check_path_s3, _C, _T
+
+from typing import Dict, List, Optional
 
 
 class BasePayload(BaseHandler):  # pylint: disable=too-few-public-methods
@@ -33,7 +36,7 @@ class BasePayload(BaseHandler):  # pylint: disable=too-few-public-methods
 
     """
 
-    def __init__(self, s3_config=None):
+    def __init__(self, s3_config: Optional[_T] = None):
         super(BasePayload, self).__init__(s3_config=s3_config)
 
     @staticmethod
@@ -268,7 +271,7 @@ class AttrPayload(BasePayload):
 
     """
 
-    def __init__(self, s3_config=None):
+    def __init__(self, s3_config: Optional[_T] = None):
         """Init for AttrPayload
 
         Args:
@@ -299,12 +302,14 @@ class AttrPayload(BasePayload):
         class_names = [val.__name__ for val in input_classes]
         # Parse out the types if generic
         type_fields = get_type_fields(input_classes)
+        flat_fields = flatten_type_dict(type_fields)
         for keys, values in base_payload.items():
             if keys not in ignore_fields:
                 # check if the keys, value pair is expected by the attr class
                 if keys != "config":
-                    # Dict infers that we are overriding a global setting in a specific config
-                    if isinstance(values, dict):
+                    # Dict infers that we are overriding a global setting in a specific config -- if it's not in the
+                    # flattened field of all parameters
+                    if isinstance(values, (dict, Dict)) and keys not in flat_fields:
                         # we're in a namespace
                         # Check for incorrect specific override of global def
                         if keys not in attr_fields:
@@ -319,7 +324,7 @@ class AttrPayload(BasePayload):
                     else:
                         # Check if the key is actually a reference to another class
                         if keys in class_names:
-                            if isinstance(values, list):
+                            if isinstance(values, (list, List)):
                                 # Check for incorrect specific override of global def
                                 if keys not in attr_fields:
                                     raise ValueError(
@@ -349,7 +354,8 @@ class AttrPayload(BasePayload):
                     payload[keys].update(values)
                 else:
                     payload[keys] = values
-        tuple_payload = convert_to_tuples(payload, type_fields, class_names)
+        tuple_payload = convert_to_tuples(payload, type_fields, flat_fields, class_names)
+        # tuple_payload = convert_to_tuples(payload, type_fields, class_names)
         payload = deep_update(payload, tuple_payload)
         return payload
 

--- a/spock/backend/payload.py
+++ b/spock/backend/payload.py
@@ -10,18 +10,17 @@ import sys
 from abc import abstractmethod
 from itertools import chain
 from pathlib import Path
+from typing import Dict, List, Optional
 
 from spock.backend.handler import BaseHandler
 from spock.backend.utils import (
     convert_to_tuples,
     deep_update,
+    flatten_type_dict,
     get_attr_fields,
     get_type_fields,
-    flatten_type_dict
 )
-from spock.utils import check_path_s3, _C, _T
-
-from typing import Dict, List, Optional
+from spock.utils import _C, _T, check_path_s3
 
 
 class BasePayload(BaseHandler):  # pylint: disable=too-few-public-methods
@@ -354,7 +353,9 @@ class AttrPayload(BasePayload):
                     payload[keys].update(values)
                 else:
                     payload[keys] = values
-        tuple_payload = convert_to_tuples(payload, type_fields, flat_fields, class_names)
+        tuple_payload = convert_to_tuples(
+            payload, type_fields, flat_fields, class_names
+        )
         # tuple_payload = convert_to_tuples(payload, type_fields, class_names)
         payload = deep_update(payload, tuple_payload)
         return payload

--- a/spock/backend/saver.py
+++ b/spock/backend/saver.py
@@ -4,15 +4,15 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """Handles prepping and saving the Spock config"""
-from typing import Dict, Optional, Set, Any, List, Tuple, Callable, Union
 from abc import abstractmethod
+from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Union
 from uuid import uuid4
 
 import attr
 
 from spock.backend.handler import BaseHandler
+from spock.backend.utils import _callable_2_str, _get_iter, _recurse_callables
 from spock.backend.wrappers import Spockspace
-from spock.backend.utils import _callable_2_str, _recurse_callables, _get_iter
 from spock.utils import add_info
 
 
@@ -250,7 +250,11 @@ class AttrSaver(BaseSaver):
         return clean_val
 
     def _recursively_handle_clean(
-        self, payload: Spockspace, out_dict: Dict, parent_name: Optional[str] = None, all_cls: Optional[Set] = None
+        self,
+        payload: Spockspace,
+        out_dict: Dict,
+        parent_name: Optional[str] = None,
+        all_cls: Optional[Set] = None,
     ) -> Dict:
         """Recursively works through spock classes and adds clean data to a dictionary
 
@@ -273,9 +277,15 @@ class AttrSaver(BaseSaver):
             # If v is any iterable we need to step into the nested structure
             if isinstance(val, (dict, Dict, list, List, tuple, Tuple)):
                 # Need to inspect list type for lists of spock classes which must be handled differently
-                mod_val = self._check_list_of_spock_classes(val, key, all_cls) if isinstance(val, (list, List)) else val
+                mod_val = (
+                    self._check_list_of_spock_classes(val, key, all_cls)
+                    if isinstance(val, (list, List))
+                    else val
+                )
                 # Recurses all iterables to find all callables and casts them to strings
-                clean_val = _recurse_callables(mod_val, _callable_2_str, check_type=Callable)
+                clean_val = _recurse_callables(
+                    mod_val, _callable_2_str, check_type=Callable
+                )
                 out_dict.update({key: clean_val})
             # Catch any callables -- convert back to the str representation
             elif callable(val):

--- a/spock/backend/saver.py
+++ b/spock/backend/saver.py
@@ -4,13 +4,15 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """Handles prepping and saving the Spock config"""
-import typing
+from typing import Dict, Optional, Set, Any, List, Tuple, Callable, Union
 from abc import abstractmethod
 from uuid import uuid4
 
 import attr
 
 from spock.backend.handler import BaseHandler
+from spock.backend.wrappers import Spockspace
+from spock.backend.utils import _callable_2_str, _recurse_callables, _get_iter
 from spock.utils import add_info
 
 
@@ -29,7 +31,7 @@ class BaseSaver(BaseHandler):  # pylint: disable=too-few-public-methods
     def __init__(self, s3_config=None):
         super(BaseSaver, self).__init__(s3_config=s3_config)
 
-    def dict_payload(self, payload):
+    def dict_payload(self, payload: Spockspace) -> Dict:
         """Clean up the config payload so it can be returned as a dict representation
 
         Args:
@@ -44,15 +46,15 @@ class BaseSaver(BaseHandler):  # pylint: disable=too-few-public-methods
 
     def save(
         self,
-        payload,
-        path,
-        file_name=None,
-        create_save_path=False,
-        extra_info=True,
-        file_extension=".yaml",
-        tuner_payload=None,
-        fixed_uuid=None,
-    ):  # pylint: disable=too-many-arguments
+        payload: Spockspace,
+        path: str,
+        file_name: Optional[str] = None,
+        create_save_path: bool = False,
+        extra_info: bool = True,
+        file_extension: str = ".yaml",
+        tuner_payload: Optional[Spockspace] = None,
+        fixed_uuid: Optional[str] = None,
+    ) -> None:  # pylint: disable=too-many-arguments
         """Writes Spock config to file
 
         Cleans and builds an output payload and then correctly writes it to file based on the
@@ -104,7 +106,7 @@ class BaseSaver(BaseHandler):  # pylint: disable=too-few-public-methods
             raise e
 
     @abstractmethod
-    def _clean_up_values(self, payload):
+    def _clean_up_values(self, payload: Spockspace) -> Dict:
         """Clean up the config payload so it can be written to file
 
         Args:
@@ -116,7 +118,7 @@ class BaseSaver(BaseHandler):  # pylint: disable=too-few-public-methods
         """
 
     @abstractmethod
-    def _clean_tuner_values(self, payload):
+    def _clean_tuner_values(self, payload: Spockspace) -> Dict:
         """Cleans up the base tuner payload that is not sampled
 
         Args:
@@ -127,94 +129,49 @@ class BaseSaver(BaseHandler):  # pylint: disable=too-few-public-methods
 
         """
 
-    def _clean_output(self, out_dict):
-        """Clean up the dictionary so it can be written to file
+    def _clean_output(self, out_dict: Dict) -> Dict:
+        """Clean up the dictionary such that it can be written to file
 
         Args:
-            out_dict: cleaned dictionary
-            extra_info: boolean to add extra info
+            out_dict: pre-cleaned dictionary
 
         Returns:
             clean_dict: cleaned output payload
 
         """
-        # Convert values
         clean_dict = {}
-        for key, val in out_dict.items():
-            clean_inner_dict = {}
-            if isinstance(val, list):
-                for idx, list_val in enumerate(val):
-                    tmp_dict = {}
-                    for inner_key, inner_val in list_val.items():
-                        tmp_dict = self._convert_tuples_2_lists(
-                            tmp_dict, inner_val, inner_key
-                        )
-                    val[idx] = tmp_dict
-                clean_inner_dict = val
-            else:
-                for inner_key, inner_val in val.items():
-                    clean_inner_dict = self._convert_tuples_2_lists(
-                        clean_inner_dict, inner_val, inner_key
-                    )
-            clean_dict.update({key: clean_inner_dict})
+        for k, v in out_dict.items():
+            if v is not None:
+                clean_dict.update({k: self._recursive_tuple_2_list(v)})
         return clean_dict
 
-    def _convert_tuples_2_lists(self, clean_inner_dict, inner_val, inner_key):
-        """Convert tuples to lists
+    def _recursive_tuple_2_list(self, val: Any) -> Any:
+        """Recursively find tuples and cast them to lists
 
         Args:
-            clean_inner_dict: dictionary to update
-            inner_val: current value
-            inner_key: current key
+            val: current value of various types
 
         Returns:
-            updated dictionary where tuples are cast back to lists
+            modified version of val
 
         """
-        # Convert tuples to lists so they get written correctly
-        if isinstance(inner_val, tuple):
-            clean_inner_dict.update(
-                {inner_key: self._recursive_tuple_to_list(inner_val)}
-            )
-        elif inner_val is not None:
-            clean_inner_dict.update({inner_key: inner_val})
-        return clean_inner_dict
-
-    def _callable_2_str(self, val):
-        """Converts a callable to a str based on the module and name
-
-        Args:
-            val: callable object
-
-        Returns:
-            string of module.name
-
-        """
-        return f"{val.__module__}.{val.__name__}"
-
-    def _recursive_tuple_to_list(self, value):
-        """Recursively turn tuples into lists
-
-        Recursively looks through tuple(s) and convert to lists
-
-        Args:
-            value: value to check and set typ if necessary
-            typed: type of the generic alias to check against
-
-        Returns:
-            value: updated value with correct type casts
-
-        """
-        # Check for __args__ as it signifies a generic and make sure it's not already been cast as a tuple
-        # from a composed payload
-        list_v = []
-        for v in value:
-            if isinstance(v, tuple):
-                v = self._recursive_tuple_to_list(v)
-                list_v.append(v)
-            else:
-                list_v.append(v)
-        return list_v
+        # If it is a tuple then we need to cast back -- do this first
+        # so we can assign by idx unlike tuples
+        if isinstance(val, (tuple, Tuple)):
+            val = list(val)
+        if isinstance(val, (list, List)):
+            for idx, v in _get_iter(val):
+                if isinstance(v, (dict, Dict, list, List, tuple, Tuple)):
+                    val[idx] = self._recursive_tuple_2_list(v)
+        elif isinstance(val, (dict, Dict)):
+            new_dict = {}
+            for k, v in _get_iter(val):
+                if isinstance(v, (dict, Dict, list, List, tuple, Tuple)):
+                    new_dict[k] = self._recursive_tuple_2_list(v)
+                elif v is not None:
+                    new_dict[k] = v
+            val = new_dict
+        return val
 
 
 class AttrSaver(BaseSaver):
@@ -234,7 +191,7 @@ class AttrSaver(BaseSaver):
     def __call__(self, *args, **kwargs):
         return AttrSaver(*args, **kwargs)
 
-    def _clean_up_values(self, payload):
+    def _clean_up_values(self, payload: Spockspace) -> Dict:
         # Dictionary to recursively write to
         out_dict = {}
         # All of the classes are defined at the top level
@@ -248,7 +205,7 @@ class AttrSaver(BaseSaver):
         clean_dict = {k: v for k, v in clean_dict.items() if len(v) > 0}
         return clean_dict
 
-    def _clean_tuner_values(self, payload):
+    def _clean_tuner_values(self, payload: Spockspace) -> Dict:
         # Just a double nested dict comprehension to unroll to dicts
         out_dict = {
             k: {ik: vars(iv) for ik, iv in vars(v).items()}
@@ -258,9 +215,43 @@ class AttrSaver(BaseSaver):
         clean_dict = self._clean_output(out_dict)
         return clean_dict
 
+    @staticmethod
+    def _check_list_of_spock_classes(val: List, key: str, all_cls: Set) -> List:
+        """Finds lists of spock classes and handles changing them to a writeable format
+
+        Args:
+            val: current value that is a list
+            key: current dictionary key in the payload
+            all_cls: set of all spock classes
+
+        Returns:
+
+        """
+        # Check if each entry is a spock class
+        clean_val = []
+        repeat_flag = False
+        for v in val:
+            cls_name = type(v).__name__
+            # For those that are a spock class and are repeated (cls_name == key) simply convert to dict
+            if (cls_name in all_cls) and (cls_name == key):
+                clean_val.append(attr.asdict(v))
+            # For those whose cls is different than the key just append the cls name
+            elif cls_name in all_cls:
+                # Change the flag as this is a repeated class -- which needs to be compressed into a single
+                # k:v pair
+                repeat_flag = True
+                clean_val.append(cls_name)
+            # Fall back to the passed in values
+            else:
+                clean_val.append(v)
+        # Handle repeated classes
+        if repeat_flag:
+            clean_val = list(set(clean_val))[-1]
+        return clean_val
+
     def _recursively_handle_clean(
-        self, payload, out_dict, parent_name=None, all_cls=None
-    ):
+        self, payload: Spockspace, out_dict: Dict, parent_name: Optional[str] = None, all_cls: Optional[Set] = None
+    ) -> Dict:
         """Recursively works through spock classes and adds clean data to a dictionary
 
         Given a payload (Spockspace) work recursively through items that don't have parents to catch all
@@ -279,38 +270,20 @@ class AttrSaver(BaseSaver):
         """
         for key, val in vars(payload).items():
             val_name = type(val).__name__
-            # This catches basic lists and list of classes
-            if isinstance(val, list):
-                # Check if each entry is a spock class
-                clean_val = []
-                repeat_flag = False
-                for l_val in val:
-                    cls_name = type(l_val).__name__
-                    # For those that are a spock class and are repeated (cls_name == key) simply convert to dict
-                    if (cls_name in all_cls) and (cls_name == key):
-                        clean_val.append(attr.asdict(l_val))
-                    elif callable(l_val):
-                        clean_val.append(self._callable_2_str(l_val))
-                    # For those whose cls is different than the key just append the cls name
-                    elif cls_name in all_cls:
-                        # Change the flag as this is a repeated class -- which needs to be compressed into a single
-                        # k:v pair
-                        repeat_flag = True
-                        clean_val.append(cls_name)
-                    # Fall back to the passed in values
-                    else:
-                        clean_val.append(l_val)
-                # Handle repeated classes
-                if repeat_flag:
-                    clean_val = list(set(clean_val))[-1]
+            # If v is any iterable we need to step into the nested structure
+            if isinstance(val, (dict, Dict, list, List, tuple, Tuple)):
+                # Need to inspect list type for lists of spock classes which must be handled differently
+                mod_val = self._check_list_of_spock_classes(val, key, all_cls) if isinstance(val, (list, List)) else val
+                # Recurses all iterables to find all callables and casts them to strings
+                clean_val = _recurse_callables(mod_val, _callable_2_str, check_type=Callable)
                 out_dict.update({key: clean_val})
             # Catch any callables -- convert back to the str representation
             elif callable(val):
-                out_dict.update({key: self._callable_2_str(val)})
+                out_dict.update({key: _callable_2_str(val)})
             # If it's a spock class but has a parent then just use the class name to reference the values
             elif (val_name in all_cls) and parent_name is not None:
                 out_dict.update({key: val_name})
-            # Check if it's a spock class without a parent -- iterate the values and recurse to catch more lists
+            # Check if it's a spock class without a parent -- iterate the values and recurse to catch more iterables
             elif val_name in all_cls:
                 new_dict = self._recursively_handle_clean(
                     val, {}, parent_name=key, all_cls=all_cls

--- a/spock/backend/typed.py
+++ b/spock/backend/typed.py
@@ -11,6 +11,7 @@ from functools import partial
 from typing import Dict, List, TypeVar, Union
 
 import attr
+
 from spock.backend.utils import _get_name_py_version
 from spock.utils import _SpockGenericAlias, _SpockVariadicGenericAlias
 
@@ -63,7 +64,10 @@ def _recursive_generic_validator(typed):
     if hasattr(typed, "__args__") and not isinstance(typed, _SpockVariadicGenericAlias):
         # Iterate through since there might be multiple types?
         # Handle List and Tuple types
-        if _get_name_py_version(typed) == "List" or _get_name_py_version(typed) == "Tuple":
+        if (
+            _get_name_py_version(typed) == "List"
+            or _get_name_py_version(typed) == "Tuple"
+        ):
             # If there are more __args__ then we still need to recurse as it is still a GenericAlias
             if len(typed.__args__) > 1:
                 return_type = attr.validators.deep_iterable(
@@ -80,10 +84,14 @@ def _recursive_generic_validator(typed):
         elif _get_name_py_version(typed) == "Dict":
             key_type, value_type = typed.__args__
             if key_type is not str:
-                raise TypeError(f"Unexpected key type of `{str(key_type.__name__)}` when attempting to handle "
-                                f"GenericAlias type of Dict -- currently Spock only supports str as keys due "
-                                f"to maintaining support for valid TOML and JSON files")
-            if hasattr(value_type, "__args__") and not isinstance(typed, _SpockVariadicGenericAlias):
+                raise TypeError(
+                    f"Unexpected key type of `{str(key_type.__name__)}` when attempting to handle "
+                    f"GenericAlias type of Dict -- currently Spock only supports str as keys due "
+                    f"to maintaining support for valid TOML and JSON files"
+                )
+            if hasattr(value_type, "__args__") and not isinstance(
+                typed, _SpockVariadicGenericAlias
+            ):
                 return_type = attr.validators.deep_mapping(
                     value_validator=_recursive_generic_validator(value_type),
                     key_validator=attr.validators.instance_of(key_type),
@@ -95,7 +103,9 @@ def _recursive_generic_validator(typed):
                 )
             return return_type
         else:
-            raise TypeError(f"Unexpected type of `{str(typed)}` when attempting to handle GenericAlias types")
+            raise TypeError(
+                f"Unexpected type of `{str(typed)}` when attempting to handle GenericAlias types"
+            )
     else:
         # If no more __args__ then we are to the base type and need to bubble up the type
         # But we need to check against base types and enums

--- a/spock/backend/utils.py
+++ b/spock/backend/utils.py
@@ -5,12 +5,11 @@
 
 """Attr utility functions for Spock"""
 
-from spock.utils import _SpockVariadicGenericAlias, _T, _C
-from spock.exceptions import _SpockValueError
-
-from typing import Any, Callable, Dict, List, Tuple, Union, Type
-
 import importlib
+from typing import Any, Callable, Dict, List, Tuple, Type, Union
+
+from spock.exceptions import _SpockValueError
+from spock.utils import _C, _T, _SpockVariadicGenericAlias
 
 
 def _str_2_callable(val: str, **kwargs):
@@ -158,7 +157,9 @@ def flatten_type_dict(type_dict: Dict):
     for k, v in type_dict.items():
         if isinstance(v, dict):
             # return_dict = flatten_type_dict(v, input_dict)
-            return_dict = flatten_type_dict(v,)
+            return_dict = flatten_type_dict(
+                v,
+            )
             flat_dict.update(return_dict)
         else:
             flat_dict[k] = v
@@ -183,7 +184,9 @@ def _get_iter(value: Union[List, Dict]):
         raise ValueError(f"Cannot get iterator for type `{type(value)}`")
 
 
-def convert_to_tuples(input_dict: Dict, base_type_dict: Dict, flat_type_dict: Dict, class_names: List):
+def convert_to_tuples(
+    input_dict: Dict, base_type_dict: Dict, flat_type_dict: Dict, class_names: List
+):
     """Convert lists to tuples
 
     Payloads from markup come in as Lists and not Tuples. This function turns lists in to tuples for the payloads
@@ -207,7 +210,9 @@ def convert_to_tuples(input_dict: Dict, base_type_dict: Dict, flat_type_dict: Di
             if isinstance(v, (dict, Dict, list, List, tuple, Tuple)):
                 # We've hit a fundamental declared type -- recurse via type checking
                 if k in flat_type_dict:
-                    updated = _recursive_list_to_tuple(k, v, flat_type_dict[k], class_names)
+                    updated = _recursive_list_to_tuple(
+                        k, v, flat_type_dict[k], class_names
+                    )
                     if updated:
                         updated_dict.update({k: updated})
                 # Have to handle this specifically -- this is lists of spock classes
@@ -223,7 +228,9 @@ def convert_to_tuples(input_dict: Dict, base_type_dict: Dict, flat_type_dict: Di
                     updated_dict.update({k: updated_list})
                 # Keep recursing through the structure
                 else:
-                    updated = convert_to_tuples(v, base_type_dict, flat_type_dict, class_names)
+                    updated = convert_to_tuples(
+                        v, base_type_dict, flat_type_dict, class_names
+                    )
                     if updated:
                         updated_dict.update({k: updated})
             # If there is no nested structure then just map
@@ -282,9 +289,7 @@ def _recursive_list_to_tuple(key: str, value: Any, typed: _T, class_names: List)
     ):
         # Force those with origin tuple types to be of the defined length
         # Here check for tuple and check length
-        if (typed.__origin__ in (tuple, Tuple)) and len(value) != len(
-            typed.__args__
-        ):
+        if (typed.__origin__ in (tuple, Tuple)) and len(value) != len(typed.__args__):
             raise ValueError(
                 f"Tuple(s) are of a defined length -- For parameter {key} the length of the provided argument "
                 f"({len(value)}) does not match the length of the defined argument ({len(typed.__args__)})"

--- a/spock/backend/utils.py
+++ b/spock/backend/utils.py
@@ -5,10 +5,107 @@
 
 """Attr utility functions for Spock"""
 
-from spock.utils import _SpockVariadicGenericAlias
+from spock.utils import _SpockVariadicGenericAlias, _T, _C
+from spock.exceptions import _SpockValueError
+
+from typing import Any, Callable, Dict, List, Tuple, Union, Type
+
+import importlib
 
 
-def get_attr_fields(input_classes):
+def _str_2_callable(val: str, **kwargs):
+    """Tries to convert a string representation of a module and callable to the reference to the callable
+
+    If the module of callable cannot be found on the PYTHONPATH then an exception is raised
+
+    Args:
+        val: string rep of a module and callable
+        **kwargs: in case additional keyword args are passed
+
+    Returns:
+        reference to a callable
+
+    Raises:
+        _SpockValueError
+
+    """
+    str_field = str(val)
+    module, fn = str_field.rsplit(".", 1)
+    try:
+        call_ref = getattr(importlib.import_module(module), fn)
+    except Exception as e:
+        raise _SpockValueError(
+            f"Attempted to import module {module} and callable {fn} however it could not be found on the current "
+            f"python path: {e}"
+        )
+    return call_ref
+
+
+def _callable_2_str(val: Callable, **kwargs):
+    """Converts a callable to a str based on the module and name
+
+    Args:
+        val: callable object
+        **kwargs: in case additional keyword args are passed
+
+    Returns:
+        string of module.name
+
+    """
+    return f"{val.__module__}.{val.__name__}"
+
+
+def _recurse_callables(val: _T, fnc: Callable, check_type: Type = str):
+    """Recurses through objects casting any callables to the correct format
+
+    Handles both strings to callables and callables to strings depending on the function passed in
+
+    Args:
+        val: current object
+        fnc: callable
+        check_type: type to check against to verify conversion
+
+    Returns:
+        object with mapped callables/strings
+
+    """
+    if isinstance(val, (list, List, tuple, Tuple)):
+        out = []
+        for v in val:
+            if isinstance(val, (list, List, tuple, Tuple, dict, Dict)):
+                out.append(_recurse_callables(v, fnc, check_type))
+            else:
+                out.append(fnc(v))
+        out = type(val)(out)
+    elif isinstance(val, (dict, Dict)):
+        out = {}
+        for k, v in val.items():
+            if isinstance(val, (list, List, tuple, Tuple, dict, Dict)):
+                out.update({k: _recurse_callables(v, fnc, check_type)})
+            else:
+                out.update({k: fnc(v)})
+    elif isinstance(val, check_type):
+        out = fnc(val)
+    # Fall back to just passing the unmodified value back
+    else:
+        out = val
+    return out
+
+
+def _get_name_py_version(typed: _T):
+    """Gets the name of the type depending on the python version
+
+    Args:
+        typed: the type of the parameter
+
+    Returns:
+        name of the type
+
+    """
+    return typed._name if hasattr(typed, "_name") else typed.__name__
+
+
+def get_attr_fields(input_classes: List):
     """Gets the attribute fields from all classes
 
     Args:
@@ -24,7 +121,7 @@ def get_attr_fields(input_classes):
     }
 
 
-def get_type_fields(input_classes):
+def get_type_fields(input_classes: List):
     """Creates a dictionary of names and types
 
     Args:
@@ -47,7 +144,7 @@ def get_type_fields(input_classes):
     return type_fields
 
 
-def flatten_type_dict(type_dict):
+def flatten_type_dict(type_dict: Dict):
     """Flattens a nested dictionary
 
     Args:
@@ -60,50 +157,82 @@ def flatten_type_dict(type_dict):
     flat_dict = {}
     for k, v in type_dict.items():
         if isinstance(v, dict):
-            return_dict = flatten_type_dict(v)
+            # return_dict = flatten_type_dict(v, input_dict)
+            return_dict = flatten_type_dict(v,)
             flat_dict.update(return_dict)
         else:
             flat_dict[k] = v
     return flat_dict
 
 
-def convert_to_tuples(input_dict, named_type_dict, class_names):
+def _get_iter(value: Union[List, Dict]):
+    """Returns the iterator for the type
+
+    Args:
+        value: instance of type List or Dict
+
+    Returns:
+        iterator
+
+    """
+    if isinstance(value, (list, List)):
+        return enumerate(value)
+    elif isinstance(value, (dict, Dict)):
+        return value.items()
+    else:
+        raise ValueError(f"Cannot get iterator for type `{type(value)}`")
+
+
+def convert_to_tuples(input_dict: Dict, base_type_dict: Dict, flat_type_dict: Dict, class_names: List):
     """Convert lists to tuples
 
     Payloads from markup come in as Lists and not Tuples. This function turns lists in to tuples for the payloads
-    so the attr values are set correctly. Will call itself recursively if a dictionary is present for class specific
-    values
+    so the attr values are set correctly. Will call itself recursively if it is iterable. Handles list of classes
+    specifically
 
     Args:
         input_dict: input dictionary
-        named_type_dict: dictionary of names with generic types
+        base_type_dict: dictionary of nested types
+        flat_type_dict: dictionary of names with generic types
+        class_names: List of base spock class names
 
     Returns:
         updated_dict: a dictionary with lists converted to tuples
 
     """
     updated_dict = {}
-    all_typed_dict = flatten_type_dict(named_type_dict)
     for k, v in input_dict.items():
         if k != "config":
-            if isinstance(v, dict):
-                updated = convert_to_tuples(v, named_type_dict.get(k), class_names)
-                if updated:
-                    updated_dict.update({k: updated})
-            elif isinstance(v, list) and k in class_names:
-                for val in v:
-                    updated = convert_to_tuples(
-                        val, named_type_dict.get(k), class_names
-                    )
+            # If v is any iterable we need to step into the nested structure
+            if isinstance(v, (dict, Dict, list, List, tuple, Tuple)):
+                # We've hit a fundamental declared type -- recurse via type checking
+                if k in flat_type_dict:
+                    updated = _recursive_list_to_tuple(k, v, flat_type_dict[k], class_names)
                     if updated:
                         updated_dict.update({k: updated})
-            elif all_typed_dict[k] is not None:
-                updated = _recursive_list_to_tuple(k, v, all_typed_dict[k], class_names)
-                updated_dict.update({k: updated})
+                # Have to handle this specifically -- this is lists of spock classes
+                # here we need to update a list instead of the dict directly
+                elif isinstance(v, (list, List)) and k in class_names:
+                    updated_list = []
+                    # Iterate over list of classes
+                    for _, val in _get_iter(v):
+                        updated = convert_to_tuples(
+                            val, base_type_dict, flat_type_dict, class_names
+                        )
+                        updated_list.append(updated)
+                    updated_dict.update({k: updated_list})
+                # Keep recursing through the structure
+                else:
+                    updated = convert_to_tuples(v, base_type_dict, flat_type_dict, class_names)
+                    if updated:
+                        updated_dict.update({k: updated})
+            # If there is no nested structure then just map
+            else:
+                updated_dict.update({k: v})
     return updated_dict
 
 
-def deep_update(source, updates):
+def deep_update(source: Dict, updates: Dict):
     """Deeply updates a dictionary
 
     Iterates through a dictionary recursively to update individual values within a possibly nested dictionary
@@ -118,7 +247,7 @@ def deep_update(source, updates):
 
     """
     for k, v in updates.items():
-        if isinstance(v, dict) and v:
+        if isinstance(v, (dict, Dict)) and v:
             updated_dict = deep_update(source.get(k), v)
             if updated_dict:
                 source[k] = updated_dict
@@ -127,7 +256,7 @@ def deep_update(source, updates):
     return source
 
 
-def _recursive_list_to_tuple(key, value, typed, class_names):
+def _recursive_list_to_tuple(key: str, value: Any, typed: _T, class_names: List):
     """Recursively turn lists into tuples
 
     Recursively looks through a pair of value and type and sets any of the possibly nested type of value to tuple
@@ -135,7 +264,7 @@ def _recursive_list_to_tuple(key, value, typed, class_names):
 
     Args:
         key: name of parameter
-        value: value to check and set typ if necessary
+        value: value to check and set type if necessary
         typed: type of the generic alias to check against
         class_names: list of all spock class names
 
@@ -152,7 +281,8 @@ def _recursive_list_to_tuple(key, value, typed, class_names):
         and not isinstance(typed, _SpockVariadicGenericAlias)
     ):
         # Force those with origin tuple types to be of the defined length
-        if (typed.__origin__.__name__.lower() == "tuple") and len(value) != len(
+        # Here check for tuple and check length
+        if (typed.__origin__ in (tuple, Tuple)) and len(value) != len(
             typed.__args__
         ):
             raise ValueError(
@@ -160,13 +290,23 @@ def _recursive_list_to_tuple(key, value, typed, class_names):
                 f"({len(value)}) does not match the length of the defined argument ({len(typed.__args__)})"
             )
         # need to recurse before casting as we can't set values in a tuple with idx
-        # Since it's generic it should be iterable to recurse and check it's children
-        for idx, val in enumerate(value):
-            value[idx] = _recursive_list_to_tuple(
-                key, val, typed.__args__[0], class_names
-            )
-        # First check if list and then swap to tuple if the origin is tuple
-        if isinstance(value, list) and typed.__origin__.__name__.lower() == "tuple":
+        # Since it's generic it should be iterable  -- thus recurse and check its children
+        if isinstance(value, (list, List)):
+            # Then we continue to recurse
+            # Iterate the list type and recurse call
+            for idx, val in _get_iter(value):
+                value[idx] = _recursive_list_to_tuple(
+                    key, val, typed.__args__[0], class_names
+                )
+        elif isinstance(value, (dict, Dict)):
+            # Iterate the dict type and recurse call
+            for k, v in _get_iter(value):
+                key_type, val_type = typed.__args__
+                value[k] = _recursive_list_to_tuple(key, v, val_type, class_names)
+        # We need to catch the mismatch if the current type is list and the given type is Tuple
+        # First check if list and then swap to tuple if the origin is tuple -- only do this on the bubble up since
+        # we can't assign by idx once we change to Tuple
+        if isinstance(value, (list, List)) and typed.__origin__ in (tuple, Tuple):
             value = tuple(value)
     else:
         return value

--- a/spock/builder.py
+++ b/spock/builder.py
@@ -7,7 +7,7 @@
 
 import argparse
 import sys
-import typing
+from typing import Optional, Tuple, List, Union, Dict, Type
 from collections import Counter
 from copy import deepcopy
 from pathlib import Path
@@ -20,9 +20,7 @@ from spock.backend.payload import AttrPayload
 from spock.backend.saver import AttrSaver
 from spock.backend.wrappers import Spockspace
 from spock.exceptions import _SpockEvolveError, _SpockUndecoratedClass
-from spock.utils import _is_spock_instance, check_payload_overwrite, deep_payload_update
-
-_CLS = typing.TypeVar("_CLS", bound=type)
+from spock.utils import _is_spock_instance, check_payload_overwrite, deep_payload_update, _C, _T
 
 
 class ConfigArgBuilder:
@@ -58,11 +56,11 @@ class ConfigArgBuilder:
     def __init__(
         self,
         *args,
-        configs: typing.Optional[typing.List] = None,
+        configs: Optional[List] = None,
         desc: str = "",
         lazy: bool = False,
         no_cmd_line: bool = False,
-        s3_config=None,
+        s3_config: Optional[_T] = None,
         **kwargs,
     ):
         """Init call for ConfigArgBuilder
@@ -127,7 +125,7 @@ class ConfigArgBuilder:
             self._print_usage_and_exit(str(e), sys_exit=False)
             raise e
 
-    def __call__(self, *args, **kwargs):
+    def __call__(self, *args, **kwargs) -> _T:
         """Call to self to allow chaining
 
         Args:
@@ -159,7 +157,7 @@ class ConfigArgBuilder:
         """Returns a Spockspace of the best hyper-parameter config and the associated metric value"""
         return self._tuner_interface.best
 
-    def sample(self):
+    def sample(self) -> Type[Spockspace]:
         """Sample method that constructs a namespace from the fixed parameters and samples from the tuner space to
         generate a Spockspace derived from both
 
@@ -178,7 +176,7 @@ class ConfigArgBuilder:
         self._sample_count += 1
         return return_tuple
 
-    def tuner(self, tuner_config):
+    def tuner(self, tuner_config: _T) -> _T:
         """Chained call that builds the tuner interface for either optuna or ax depending upon the type of the tuner_obj
 
         Args:
@@ -207,7 +205,7 @@ class ConfigArgBuilder:
             raise e
         return self
 
-    def _print_usage_and_exit(self, msg=None, sys_exit=True, exit_code=1):
+    def _print_usage_and_exit(self, msg: Optional[str] = None, sys_exit: bool = True, exit_code: int = 1) -> None:
         """Prints the help message and exits
 
         Args:
@@ -229,7 +227,7 @@ class ConfigArgBuilder:
         if sys_exit:
             sys.exit(exit_code)
 
-    def _handle_tuner_objects(self, tune_args, s3_config, kwargs):
+    def _handle_tuner_objects(self, tune_args: List, s3_config: Optional[_T], kwargs: Dict) -> Tuple:
         """Handles creating the tuner builder object if @spockTuner classes were passed in
 
         Args:
@@ -258,7 +256,7 @@ class ConfigArgBuilder:
             return None, None
 
     @staticmethod
-    def _verify_attr(args: typing.Tuple):
+    def _verify_attr(args: Tuple) -> None:
         """Verifies that all the input classes are attr based
 
         Args:
@@ -284,7 +282,7 @@ class ConfigArgBuilder:
                 )
 
     @staticmethod
-    def _strip_tune_parameters(args: typing.Tuple):
+    def _strip_tune_parameters(args: Tuple) -> Tuple[List, List]:
         """Separates the fixed arguments from any hyper-parameter arguments
 
         Args:
@@ -304,7 +302,7 @@ class ConfigArgBuilder:
                 tune_args.append(arg)
         return fixed_args, tune_args
 
-    def _handle_cmd_line(self):
+    def _handle_cmd_line(self) -> argparse.Namespace:
         """Handle all cmd line related tasks
 
         Config paths can enter from either the command line or be added in the class init call
@@ -332,7 +330,7 @@ class ConfigArgBuilder:
             args = self._get_from_kwargs(args, self._configs)
         return args
 
-    def _build_override_parsers(self, desc):
+    def _build_override_parsers(self, desc: str) -> argparse.Namespace:
         """Creates parsers for command-line overrides
 
         Builds the basic command line parser for configs and help then iterates through each attr instance to make
@@ -356,11 +354,10 @@ class ConfigArgBuilder:
         if self._tune_obj is not None:
             parser = self._tune_obj.build_override_parsers(parser=parser)
         args = parser.parse_args()
-
         return args
 
     @staticmethod
-    def _get_from_kwargs(args, configs):
+    def _get_from_kwargs(args: argparse.Namespace, configs: List):
         """Get configs from the configs kwarg
 
         Args:
@@ -379,7 +376,7 @@ class ConfigArgBuilder:
             )
         return args
 
-    def _get_payload(self, payload_obj, input_classes, ignore_args: typing.List):
+    def _get_payload(self, payload_obj: Type[AttrPayload], input_classes: Tuple, ignore_args: List) -> Dict:
         """Get the parameter payload from the config file(s)
 
         Calls the various ways to get configs and then parses to retrieve the parameter payload - make sure to call
@@ -426,15 +423,15 @@ class ConfigArgBuilder:
 
     def _save(
         self,
-        payload,
+        payload: Spockspace,
         file_name: str = None,
         user_specified_path: Path = None,
         create_save_path: bool = True,
         extra_info: bool = True,
         file_extension: str = ".yaml",
-        tuner_payload=None,
-        fixed_uuid=None,
-    ):
+        tuner_payload: Optional[Spockspace] = None,
+        fixed_uuid: str = None,
+    ) -> _T:
         """Private interface -- saves the current config setup to file with a UUID
 
         Args:
@@ -475,12 +472,12 @@ class ConfigArgBuilder:
     def save(
         self,
         file_name: str = None,
-        user_specified_path: typing.Union[Path, str] = None,
+        user_specified_path: Union[Path, str] = None,
         create_save_path: bool = True,
         extra_info: bool = True,
         file_extension: str = ".yaml",
         add_tuner_sample: bool = False,
-    ):
+    ) -> _T:
         """Saves the current config setup to file with a UUID
 
         Args:
@@ -489,7 +486,7 @@ class ConfigArgBuilder:
             create_save_path: bool to create the path to save if called
             extra_info: additional info to write to saved config (run date and git info)
             file_extension: file type to write (default: yaml)
-            append_tuner_state: save the current tuner sample to the payload
+            add_tuner_sample: save the current tuner sample to the payload
 
         Returns:
             self so that functions can be chained
@@ -537,7 +534,7 @@ class ConfigArgBuilder:
         create_save_path: bool = True,
         extra_info: bool = True,
         file_extension: str = ".yaml",
-    ):
+    ) -> _T:
         """Saves the current best config setup to file
 
         Args:
@@ -573,7 +570,7 @@ class ConfigArgBuilder:
         """Dictionary representation of the arg payload"""
         return self._saver_obj.dict_payload(self._arg_namespace)
 
-    def spockspace_2_dict(self, payload: Spockspace):
+    def spockspace_2_dict(self, payload: Spockspace) -> Dict:
         """Converts an input SpockSpace into a dictionary
 
         Args:
@@ -585,7 +582,7 @@ class ConfigArgBuilder:
         """
         return self._saver_obj.dict_payload(payload)
 
-    def evolve(self, *args: typing.Type[_CLS]):
+    def evolve(self, *args: _C) -> Spockspace:
         """Function that allows a user to evolve the underlying spock classes with instantiated spock objects
 
         This will map the differences between the passed in instantiated objects and the underlying class definitions
@@ -643,8 +640,8 @@ class ConfigArgBuilder:
         return new_arg_namespace
 
     def _recurse_upwards(
-        self, new_arg_namespace: Spockspace, current_cls: str, all_cls: typing.Dict
-    ):
+        self, new_arg_namespace: Spockspace, current_cls: str, all_cls: Dict
+    ) -> Tuple[Spockspace, Dict]:
         """Using the underlying graph work recurse upwards through the parents and swap in the correct values
 
         Args:
@@ -678,8 +675,8 @@ class ConfigArgBuilder:
 
     @staticmethod
     def _set_matching_attrs_by_name_args(
-        current_cls_name: str, parent_cls_name: str, all_cls: typing.Dict
-    ):
+        current_cls_name: str, parent_cls_name: str, all_cls: Dict
+    ) -> Dict:
         """Sets the value of an attribute by matching it to a spock class name
 
         Args:
@@ -710,7 +707,7 @@ class ConfigArgBuilder:
     @staticmethod
     def _set_matching_attrs_by_name(
         new_arg_namespace: Spockspace, current_cls_name: str, parent_cls_name: str
-    ):
+    ) -> Spockspace:
         """Sets the value of an attribute by matching it to a spock class name
 
         Args:

--- a/spock/builder.py
+++ b/spock/builder.py
@@ -7,10 +7,10 @@
 
 import argparse
 import sys
-from typing import Optional, Tuple, List, Union, Dict, Type
 from collections import Counter
 from copy import deepcopy
 from pathlib import Path
+from typing import Dict, List, Optional, Tuple, Type, Union
 from uuid import uuid4
 
 import attr
@@ -20,7 +20,13 @@ from spock.backend.payload import AttrPayload
 from spock.backend.saver import AttrSaver
 from spock.backend.wrappers import Spockspace
 from spock.exceptions import _SpockEvolveError, _SpockUndecoratedClass
-from spock.utils import _is_spock_instance, check_payload_overwrite, deep_payload_update, _C, _T
+from spock.utils import (
+    _C,
+    _T,
+    _is_spock_instance,
+    check_payload_overwrite,
+    deep_payload_update,
+)
 
 
 class ConfigArgBuilder:
@@ -205,7 +211,9 @@ class ConfigArgBuilder:
             raise e
         return self
 
-    def _print_usage_and_exit(self, msg: Optional[str] = None, sys_exit: bool = True, exit_code: int = 1) -> None:
+    def _print_usage_and_exit(
+        self, msg: Optional[str] = None, sys_exit: bool = True, exit_code: int = 1
+    ) -> None:
         """Prints the help message and exits
 
         Args:
@@ -227,7 +235,9 @@ class ConfigArgBuilder:
         if sys_exit:
             sys.exit(exit_code)
 
-    def _handle_tuner_objects(self, tune_args: List, s3_config: Optional[_T], kwargs: Dict) -> Tuple:
+    def _handle_tuner_objects(
+        self, tune_args: List, s3_config: Optional[_T], kwargs: Dict
+    ) -> Tuple:
         """Handles creating the tuner builder object if @spockTuner classes were passed in
 
         Args:
@@ -376,7 +386,9 @@ class ConfigArgBuilder:
             )
         return args
 
-    def _get_payload(self, payload_obj: Type[AttrPayload], input_classes: Tuple, ignore_args: List) -> Dict:
+    def _get_payload(
+        self, payload_obj: Type[AttrPayload], input_classes: Tuple, ignore_args: List
+    ) -> Dict:
         """Get the parameter payload from the config file(s)
 
         Calls the various ways to get configs and then parses to retrieve the parameter payload - make sure to call

--- a/spock/graph.py
+++ b/spock/graph.py
@@ -6,7 +6,7 @@
 """Handles creation and ops for DAGs"""
 
 import sys
-from typing import Dict, List, Tuple, Generator
+from typing import Dict, Generator, List, Tuple
 
 from spock.utils import _find_all_spock_classes
 

--- a/spock/graph.py
+++ b/spock/graph.py
@@ -6,7 +6,7 @@
 """Handles creation and ops for DAGs"""
 
 import sys
-from typing import Type
+from typing import Dict, List, Tuple, Generator
 
 from spock.utils import _find_all_spock_classes
 
@@ -21,7 +21,7 @@ class Graph:
 
     """
 
-    def __init__(self, input_classes, lazy: bool):
+    def __init__(self, input_classes: List, lazy: bool):
         """Init call for Graph class
 
         Args:
@@ -81,7 +81,7 @@ class Graph:
         return self._topological_sort()
 
     @staticmethod
-    def _yield_class_deps(classes):
+    def _yield_class_deps(classes: List) -> Generator[Tuple, None, None]:
         """Generator to iterate through nodes and find dependencies
 
         Args:
@@ -96,7 +96,7 @@ class Graph:
             for v in dep_names:
                 yield input_class, v
 
-    def _lazily_find_classes(self, classes):
+    def _lazily_find_classes(self, classes: List) -> Tuple:
         """Searches within the spock sys modules attributes to lazily find @spock decorated classes
 
         These classes have been decorated with @spock but might not have been passes into the ConfigArgBuilder so
@@ -129,7 +129,7 @@ class Graph:
                 lazy_classes.append(lazy_class)
         return tuple(lazy_classes)
 
-    def _lazily_find_parents(self):
+    def _lazily_find_parents(self) -> Tuple:
         """Searches within the current set of input_classes (@spock decorated classes) to lazily find any parents
 
         Given that lazy inheritance means that the parent classes won't be included (since they are cast to spock
@@ -158,7 +158,7 @@ class Graph:
                         lazy_parents.update({base.__name__: base})
         return tuple(lazy_parents.values())
 
-    def _build(self):
+    def _build(self) -> Dict:
         """Builds a dictionary of nodes and their edges (essentially builds the DAG)
 
         Returns:
@@ -179,7 +179,7 @@ class Graph:
         nodes = {key: set(val) for key, val in nodes.items()}
         return nodes
 
-    def _has_cycles(self):
+    def _has_cycles(self) -> bool:
         """Uses DFS to check for cycles within the spock dependency graph
 
         Returns:
@@ -198,7 +198,7 @@ class Graph:
                     return True
         return False
 
-    def _cycle_dfs(self, node: Type, visited: dict, recursion_stack: dict):
+    def _cycle_dfs(self, node: str, visited: Dict, recursion_stack: Dict) -> bool:
         """DFS via a recursion stack for cycles
 
         Args:
@@ -227,7 +227,7 @@ class Graph:
         recursion_stack.update({node: False})
         return False
 
-    def _topological_sort(self):
+    def _topological_sort(self) -> List:
         # DFS for topological sort
         # https://en.wikipedia.org/wiki/Topological_sorting
         visited = {key: False for key in self.node_names}
@@ -239,7 +239,7 @@ class Graph:
         stack.reverse()
         return stack
 
-    def _topological_sort_dfs(self, node, visited, stack):
+    def _topological_sort_dfs(self, node: str, visited: Dict, stack: List) -> None:
         # Update the visited dict
         visited.update({node: True})
         # Recur for all edges

--- a/spock/handlers.py
+++ b/spock/handlers.py
@@ -8,7 +8,7 @@
 import json
 import os
 import re
-import typing
+from typing import Dict, Optional, Tuple, Union
 from abc import ABC, abstractmethod
 from pathlib import Path, PurePosixPath
 from warnings import warn
@@ -29,7 +29,7 @@ class Handler(ABC):
 
     """
 
-    def load(self, path: Path, s3_config=None) -> typing.Dict:
+    def load(self, path: Path, s3_config=None) -> Dict:
         """Load function for file type
 
         This handles s3 path conversion for all handler types pre load call
@@ -56,7 +56,7 @@ class Handler(ABC):
         return payload
 
     @abstractmethod
-    def _load(self, path: str) -> typing.Dict:
+    def _load(self, path: str) -> Dict:
         """Private load function for file type
 
         Args:
@@ -70,8 +70,8 @@ class Handler(ABC):
 
     def save(
         self,
-        out_dict: typing.Dict,
-        info_dict: typing.Optional[typing.Dict],
+        out_dict: Dict,
+        info_dict: Optional[Dict],
         path: Path,
         name: str,
         create_path: bool = False,
@@ -112,7 +112,7 @@ class Handler(ABC):
 
     @abstractmethod
     def _save(
-        self, out_dict: typing.Dict, info_dict: typing.Optional[typing.Dict], path: str
+        self, out_dict: Dict, info_dict: Optional[Dict], path: str
     ) -> str:
         """Write function for file type
 
@@ -128,7 +128,7 @@ class Handler(ABC):
     @staticmethod
     def _handle_possible_s3_load_path(
         path: Path, s3_config=None
-    ) -> typing.Union[str, Path]:
+    ) -> Union[str, Path]:
         """Handles the possibility of having to handle loading from a S3 path
 
         Checks to see if it detects a S3 uri and if so triggers imports of s3 functionality and handles the file
@@ -156,7 +156,7 @@ class Handler(ABC):
     @staticmethod
     def _handle_possible_s3_save_path(
         path: Path, name: str, create_path: bool, s3_config=None
-    ) -> typing.Tuple[str, bool]:
+    ) -> Tuple[str, bool]:
         """Handles the possibility of having to save to a S3 path
 
         Checks to see if it detects a S3 uri and if so generates a tmp location to write the file to pre-upload
@@ -231,7 +231,7 @@ class YAMLHandler(Handler):
         list("-+0123456789."),
     )
 
-    def _load(self, path: str) -> typing.Dict:
+    def _load(self, path: str) -> Dict:
         """YAML load function
 
         Args:
@@ -247,8 +247,8 @@ class YAMLHandler(Handler):
         return base_payload
 
     def _save(
-        self, out_dict: typing.Dict, info_dict: typing.Optional[typing.Dict], path: str
-    ):
+        self, out_dict: Dict, info_dict: Optional[Dict], path: str
+    ) -> str:
         """Write function for YAML type
 
         Args:
@@ -274,7 +274,7 @@ class TOMLHandler(Handler):
 
     """
 
-    def _load(self, path: str) -> typing.Dict:
+    def _load(self, path: str) -> Dict:
         """TOML load function
 
         Args:
@@ -288,8 +288,8 @@ class TOMLHandler(Handler):
         return base_payload
 
     def _save(
-        self, out_dict: typing.Dict, info_dict: typing.Optional[typing.Dict], path: str
-    ):
+        self, out_dict: Dict, info_dict: Optional[Dict], path: str
+    ) -> str:
         """Write function for TOML type
 
         Args:
@@ -313,7 +313,7 @@ class JSONHandler(Handler):
 
     """
 
-    def _load(self, path: str) -> typing.Dict:
+    def _load(self, path: str) -> Dict:
         """JSON load function
 
         Args:
@@ -328,8 +328,8 @@ class JSONHandler(Handler):
         return base_payload
 
     def _save(
-        self, out_dict: typing.Dict, info_dict: typing.Optional[typing.Dict], path: str
-    ):
+        self, out_dict: Dict, info_dict: Optional[Dict], path: str
+    ) -> str:
         """Write function for JSON type
 
         Args:

--- a/spock/handlers.py
+++ b/spock/handlers.py
@@ -8,9 +8,9 @@
 import json
 import os
 import re
-from typing import Dict, Optional, Tuple, Union
 from abc import ABC, abstractmethod
 from pathlib import Path, PurePosixPath
+from typing import Dict, Optional, Tuple, Union
 from warnings import warn
 
 import pytomlpp
@@ -111,9 +111,7 @@ class Handler(ABC):
                 print("Error importing spock s3 utils after detecting s3:// save path")
 
     @abstractmethod
-    def _save(
-        self, out_dict: Dict, info_dict: Optional[Dict], path: str
-    ) -> str:
+    def _save(self, out_dict: Dict, info_dict: Optional[Dict], path: str) -> str:
         """Write function for file type
 
         Args:
@@ -126,9 +124,7 @@ class Handler(ABC):
         raise NotImplementedError
 
     @staticmethod
-    def _handle_possible_s3_load_path(
-        path: Path, s3_config=None
-    ) -> Union[str, Path]:
+    def _handle_possible_s3_load_path(path: Path, s3_config=None) -> Union[str, Path]:
         """Handles the possibility of having to handle loading from a S3 path
 
         Checks to see if it detects a S3 uri and if so triggers imports of s3 functionality and handles the file
@@ -246,9 +242,7 @@ class YAMLHandler(Handler):
         base_payload = yaml.safe_load(file_contents)
         return base_payload
 
-    def _save(
-        self, out_dict: Dict, info_dict: Optional[Dict], path: str
-    ) -> str:
+    def _save(self, out_dict: Dict, info_dict: Optional[Dict], path: str) -> str:
         """Write function for YAML type
 
         Args:
@@ -287,9 +281,7 @@ class TOMLHandler(Handler):
         base_payload = pytomlpp.load(path)
         return base_payload
 
-    def _save(
-        self, out_dict: Dict, info_dict: Optional[Dict], path: str
-    ) -> str:
+    def _save(self, out_dict: Dict, info_dict: Optional[Dict], path: str) -> str:
         """Write function for TOML type
 
         Args:
@@ -327,9 +319,7 @@ class JSONHandler(Handler):
             base_payload = json.load(json_fid)
         return base_payload
 
-    def _save(
-        self, out_dict: Dict, info_dict: Optional[Dict], path: str
-    ) -> str:
+    def _save(self, out_dict: Dict, info_dict: Optional[Dict], path: str) -> str:
         """Write function for JSON type
 
         Args:

--- a/spock/utils.py
+++ b/spock/utils.py
@@ -13,8 +13,10 @@ import sys
 from enum import EnumMeta
 from pathlib import Path
 from time import localtime, strftime
-from typing import List, Type, Union
+from typing import Any, Dict, List, Tuple, Union, TypeVar, Type
 from warnings import warn
+
+from argparse import _ArgumentGroup
 
 import attr
 import git
@@ -49,6 +51,8 @@ def _get_callable_type():
 
 _SpockGenericAlias = _get_alias_type()
 _SpockVariadicGenericAlias = _get_callable_type()
+_T = TypeVar("_T")
+_C = TypeVar("_C", bound=type)
 
 
 def within(
@@ -164,7 +168,7 @@ def lt(val: Union[float, int], bound: Union[float, int]) -> None:
         )
 
 
-def _find_all_spock_classes(attr_class: Type):
+def _find_all_spock_classes(attr_class: _C) -> List:
     """Within a spock class determine if there are any references to other spock classes
 
     Args:
@@ -193,7 +197,7 @@ def _find_all_spock_classes(attr_class: Type):
     return dep_classes
 
 
-def _check_4_spock_iterable(iter_obj: Union[tuple, list]):
+def _check_4_spock_iterable(iter_obj: Union[Tuple, List]) -> bool:
     """Checks if an iterable type contains a spock class
 
     Args:
@@ -206,7 +210,7 @@ def _check_4_spock_iterable(iter_obj: Union[tuple, list]):
     return _check_iterable(iter_obj=iter_obj)
 
 
-def _get_enum_classes(enum_obj: EnumMeta):
+def _get_enum_classes(enum_obj: EnumMeta) -> List:
     """Checks if any of the values of an enum are spock classes and adds to a list
 
     Args:
@@ -245,7 +249,7 @@ def check_path_s3(path: Path) -> bool:
     return len(path.parts) > 1 and path.parts[0] == "s3:"
 
 
-def _is_spock_instance(__obj: object):
+def _is_spock_instance(__obj: object) -> bool:
     """Checks if the object is a @spock decorated class
 
     Private interface that checks to see if the object passed in is registered within the spock module and also
@@ -261,7 +265,7 @@ def _is_spock_instance(__obj: object):
     return attr.has(__obj) and (__obj.__module__ == "spock.backend.config")
 
 
-def _is_spock_tune_instance(__obj: object):
+def _is_spock_tune_instance(__obj: object) -> bool:
     """Checks if the object is a @spock decorated class
 
     Private interface that checks to see if the object passed in is registered within the spock module tune addon and also
@@ -277,7 +281,7 @@ def _is_spock_tune_instance(__obj: object):
     return attr.has(__obj) and (__obj.__module__ == "spock.addons.tune.config")
 
 
-def _check_iterable(iter_obj: Union[tuple, list, EnumMeta]):
+def _check_iterable(iter_obj: Union[Tuple, List, EnumMeta]) -> bool:
     """Check if an iterable type contains a spock class
 
     Args:
@@ -290,7 +294,7 @@ def _check_iterable(iter_obj: Union[tuple, list, EnumMeta]):
     return any([_is_spock_instance(v.value) for v in iter_obj])
 
 
-def make_argument(arg_name, arg_type, parser):
+def make_argument(arg_name: str, arg_type: _T, parser: Type[_ArgumentGroup]) -> _ArgumentGroup:
     """Make argparser argument based on type
 
     Based on the type passed in handle the creation of the argparser argument so that overrides will have the correct
@@ -330,7 +334,7 @@ def make_argument(arg_name, arg_type, parser):
     return parser
 
 
-def _handle_generic_type_args(val):
+def _handle_generic_type_args(val: str) -> Any:
     """Evaluates a string containing a Python literal
 
     Seeing a list and tuple types will come in as string literal format, use ast to get the actual type
@@ -345,7 +349,7 @@ def _handle_generic_type_args(val):
     return ast.literal_eval(val)
 
 
-def add_info():
+def add_info() -> Dict:
     """Adds extra information to the output dictionary
 
     Args:
@@ -359,7 +363,7 @@ def add_info():
     return out_dict
 
 
-def make_blank_git(out_dict):
+def make_blank_git(out_dict: Dict) -> Dict:
     """Adds blank git info
 
     Args:
@@ -374,7 +378,7 @@ def make_blank_git(out_dict):
     return out_dict
 
 
-def add_repo_info(out_dict):
+def add_repo_info(out_dict: Dict) -> Dict:
     """Adds GIT information to the output dictionary
 
     Args:
@@ -426,7 +430,7 @@ def add_repo_info(out_dict):
     return out_dict
 
 
-def add_generic_info(out_dict):
+def add_generic_info(out_dict: Dict) -> Dict:
     """Adds date, fqdn information to the output dictionary
 
     Args:
@@ -453,7 +457,7 @@ def add_generic_info(out_dict):
     return out_dict
 
 
-def _maybe_docker(cgroup_path="/proc/self/cgroup"):
+def _maybe_docker(cgroup_path: str = "/proc/self/cgroup") -> bool:
     """Make a best effort to determine if run in a docker container
 
     Args:
@@ -474,7 +478,7 @@ def _maybe_docker(cgroup_path="/proc/self/cgroup"):
     return bool_env or bool_cgroup
 
 
-def _maybe_k8s(cgroup_path="/proc/self/cgroup"):
+def _maybe_k8s(cgroup_path: str = "/proc/self/cgroup") -> bool:
     """Make a best effort to determine if run in a container via k8s
 
     Args:
@@ -495,7 +499,7 @@ def _maybe_k8s(cgroup_path="/proc/self/cgroup"):
     return bool_env or bool_cgroup
 
 
-def deep_payload_update(source, updates):
+def deep_payload_update(source: Dict, updates: Dict) -> Dict:
     """Deeply updates a dictionary
 
     Iterates through a dictionary recursively to update individual values within a possibly nested dictionary
@@ -511,7 +515,7 @@ def deep_payload_update(source, updates):
     """
 
     for k, v in updates.items():
-        if isinstance(v, dict) and v:
+        if isinstance(v, (dict, Dict)) and v:
             source_dict = {} if source.get(k) is None else source.get(k)
             updated_dict = deep_payload_update(source_dict, v)
             if updated_dict:
@@ -521,7 +525,7 @@ def deep_payload_update(source, updates):
     return source
 
 
-def check_payload_overwrite(payload, updates, configs, overwrite=""):
+def check_payload_overwrite(payload: Dict, updates: Dict, configs: str, overwrite: str = "") -> None:
     """Warns when parameters are overwritten across payloads as order will matter
 
     Args:

--- a/spock/utils.py
+++ b/spock/utils.py
@@ -10,13 +10,12 @@ import os
 import socket
 import subprocess
 import sys
+from argparse import _ArgumentGroup
 from enum import EnumMeta
 from pathlib import Path
 from time import localtime, strftime
-from typing import Any, Dict, List, Tuple, Union, TypeVar, Type
+from typing import Any, Dict, List, Tuple, Type, TypeVar, Union
 from warnings import warn
-
-from argparse import _ArgumentGroup
 
 import attr
 import git
@@ -294,7 +293,9 @@ def _check_iterable(iter_obj: Union[Tuple, List, EnumMeta]) -> bool:
     return any([_is_spock_instance(v.value) for v in iter_obj])
 
 
-def make_argument(arg_name: str, arg_type: _T, parser: Type[_ArgumentGroup]) -> _ArgumentGroup:
+def make_argument(
+    arg_name: str, arg_type: _T, parser: Type[_ArgumentGroup]
+) -> _ArgumentGroup:
     """Make argparser argument based on type
 
     Based on the type passed in handle the creation of the argparser argument so that overrides will have the correct
@@ -525,7 +526,9 @@ def deep_payload_update(source: Dict, updates: Dict) -> Dict:
     return source
 
 
-def check_payload_overwrite(payload: Dict, updates: Dict, configs: str, overwrite: str = "") -> None:
+def check_payload_overwrite(
+    payload: Dict, updates: Dict, configs: str, overwrite: str = ""
+) -> None:
     """Warns when parameters are overwritten across payloads as order will matter
 
     Args:

--- a/tests/base/attr_configs_test.py
+++ b/tests/base/attr_configs_test.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum
-from typing import List, Optional, Tuple, Callable
+from typing import List, Optional, Tuple, Callable, Dict
 
 from spock.backend.typed import SavePath
 from spock.config import spock
@@ -160,6 +160,14 @@ class TypeConfig:
     call_me: Callable
     # List of Callable
     call_us: List[Callable]
+    # Dict w/ str keys -- simple float value
+    str_dict: Dict[str, float]
+    # Dict w/ int keys -- List of strings
+    int_list_str_dict: Dict[str, List[str]]
+    # Dict w/ int keys --Tuple len 2 of Callable
+    float_tuple_callable_dict: Dict[str, Tuple[Callable, Callable]]
+    # A weird combo to see if catches hard nested values
+    hardest: List[Dict[str, Tuple[Callable, Callable]]]
 
 
 @spock
@@ -207,6 +215,14 @@ class TypeOptConfig:
     call_me_maybe: Optional[Callable]
     # List optional call me
     call_us_maybe: Optional[List[Callable]]
+    # Dict w/ str keys -- simple float value
+    str_dict_opt: Optional[Dict[str, float]]
+    # Dict w/ int keys -- List of strings
+    int_list_str_dict_opt: Optional[Dict[str, List[str]]]
+    # Dict w/ int keys --Tuple len 2 of Callable
+    float_tuple_callable_dict_opt: Optional[Dict[str, Tuple[Callable, Callable]]]
+    # A weird combo to see if catches hard nested values
+    hardest_opt: Optional[List[Dict[str, Tuple[str, str]]]]
 
 
 @spock
@@ -277,6 +293,15 @@ class TypeDefaultConfig:
     call_me_maybe_def: Callable = foo
     # List of Callable
     call_us_maybe_def: List[Callable] = [foo, foo]
+    # Dict w/ str keys -- simple float value
+    str_dict_def: Dict[str, float] = {"key_1": 1.5, "key_2": 2.5}
+    # Dict w/ int keys -- List of strings
+    int_list_str_dict_def: Dict[str, List[str]] = {"1": ['test', 'me'], "2": ['again', 'test']}
+    # Dict w/ int keys --Tuple len 2 of Callable
+    float_tuple_callable_dict_def: Dict[str, Tuple[Callable, Callable]] = {"1.0": (foo, bar), "2.0": (foo, bar)}
+    # A weird combo to see if catches hard nested values
+    hardest_def: List[Dict[str, Tuple[Callable, Callable]]] = [{"key_1": (foo, bar), "key_2": (foo, bar)},
+                                                  {"key_3": (foo, bar), "key_4": (foo, bar)}]
 
 
 @spock
@@ -325,6 +350,16 @@ class TypeDefaultOptConfig:
     call_me_maybe_opt_def: Optional[Callable] = foo
     # List optional call me
     call_us_maybe_opt_def: Optional[List[Callable]] = [foo, foo]
+    # Dict w/ str keys -- simple float value
+    str_dict_opt_def: Optional[Dict[str, float]] = {"key_1": 1.5, "key_2": 2.5}
+    # Dict w/ int keys -- List of strings
+    int_list_str_dict_opt_def: Optional[Dict[str, List[str]]] = {"1": ['test', 'me'], "2": ['again', 'test']}
+    # Dict w/ int keys --Tuple len 2 of Callable
+    float_tuple_callable_dict_opt_def: Optional[Dict[str, Tuple[Callable, Callable]]] = {"1.0": (foo, bar), "2.0": (foo, bar)}
+    # A weird combo to see if catches hard nested values
+    hardest_opt_def: Optional[List[Dict[str, Tuple[Callable, Callable]]]] = [
+        {"key_1": (foo, bar), "key_2": (foo, bar)}, {"key_3": (foo, bar), "key_4": (foo, bar)}
+    ]
 
 
 @spock

--- a/tests/base/base_asserts_test.py
+++ b/tests/base/base_asserts_test.py
@@ -2,7 +2,7 @@
 # Copyright FMR LLC <opensource@fidelity.com>
 # SPDX-License-Identifier: Apache-2.0
 
-from tests.base.attr_configs_test import FirstDoubleNestedConfig, foo
+from tests.base.attr_configs_test import FirstDoubleNestedConfig, foo, bar
 
 
 class AllTypes:
@@ -55,6 +55,13 @@ class AllTypes:
         assert arg_builder.TypeConfig.call_us[0] == foo
         assert arg_builder.TypeConfig.call_us[1] == foo
 
+        assert arg_builder.TypeConfig.str_dict == {"key_1": 1.5, "key_2": 2.5}
+        assert arg_builder.TypeConfig.int_list_str_dict == {"1": ['test', 'me'], "2": ['again', 'test']}
+        assert arg_builder.TypeConfig.float_tuple_callable_dict == {"1.0": (foo, bar), "2.0": (foo, bar)}
+        assert arg_builder.TypeConfig.hardest == [{"key_1": (foo, bar), "key_2": (foo, bar)},
+                                                  {"key_3": (foo, bar), "key_4": (foo, bar)}]
+
+
         # Optional #
         assert arg_builder.TypeOptConfig.int_p_opt_no_def is None
         assert arg_builder.TypeOptConfig.float_p_opt_no_def is None
@@ -75,6 +82,11 @@ class AllTypes:
         assert arg_builder.TypeOptConfig.class_enum_opt_no_def is None
         assert arg_builder.TypeOptConfig.call_me_maybe is None
         assert arg_builder.TypeOptConfig.call_us_maybe is None
+
+        assert arg_builder.TypeOptConfig.str_dict_opt is None
+        assert arg_builder.TypeOptConfig.int_list_str_dict_opt is None
+        assert arg_builder.TypeOptConfig.float_tuple_callable_dict_opt is None
+        assert arg_builder.TypeOptConfig.hardest_opt is None
 
 
 class AllDefaults:
@@ -131,6 +143,12 @@ class AllDefaults:
         assert arg_builder.TypeDefaultConfig.call_us_maybe_def[0] == foo
         assert arg_builder.TypeDefaultConfig.call_us_maybe_def[1] == foo
 
+        assert arg_builder.TypeDefaultConfig.str_dict_def == {"key_1": 1.5, "key_2": 2.5}
+        assert arg_builder.TypeDefaultConfig.int_list_str_dict_def == {"1": ['test', 'me'], "2": ['again', 'test']}
+        assert arg_builder.TypeDefaultConfig.float_tuple_callable_dict_def == {"1.0": (foo, bar), "2.0": (foo, bar)}
+        assert arg_builder.TypeDefaultConfig.hardest_def == [{"key_1": (foo, bar), "key_2": (foo, bar)},
+                                                             {"key_3": (foo, bar), "key_4": (foo, bar)}]
+
         # Optional w/ Defaults #
         assert arg_builder.TypeDefaultOptConfig.int_p_opt_def == 10
         assert arg_builder.TypeDefaultOptConfig.float_p_opt_def == 10.0
@@ -168,6 +186,13 @@ class AllDefaults:
         assert arg_builder.TypeDefaultOptConfig.call_me_maybe_opt_def == foo
         assert arg_builder.TypeDefaultOptConfig.call_us_maybe_opt_def[0] == foo
         assert arg_builder.TypeDefaultOptConfig.call_us_maybe_opt_def[1] == foo
+
+        assert arg_builder.TypeDefaultOptConfig.str_dict_opt_def == {"key_1": 1.5, "key_2": 2.5}
+        assert arg_builder.TypeDefaultOptConfig.int_list_str_dict_opt_def == {"1": ['test', 'me'], "2": ['again', 'test']}
+        assert arg_builder.TypeDefaultOptConfig.float_tuple_callable_dict_opt_def == {"1.0": (foo, bar), "2.0": (foo, bar)}
+        assert arg_builder.TypeDefaultOptConfig.hardest_opt_def == [
+            {"key_1": (foo, bar), "key_2": (foo, bar)}, {"key_3": (foo, bar), "key_4": (foo, bar)}
+        ]
 
 
 class AllInherited:
@@ -222,6 +247,14 @@ class AllInherited:
         assert arg_builder.TypeInherited.call_us[0] == foo
         assert arg_builder.TypeInherited.call_us[1] == foo
 
+        assert arg_builder.TypeInherited.str_dict == {"key_1": 1.5, "key_2": 2.5}
+        assert arg_builder.TypeInherited.int_list_str_dict == {"1": ['test', 'me'], "2": ['again', 'test']}
+        assert arg_builder.TypeInherited.float_tuple_callable_dict == {"1.0": (foo, bar), "2.0": (foo, bar)}
+        assert arg_builder.TypeInherited.hardest == [
+            {"key_1": (foo, bar), "key_2": (foo, bar)}, {"key_3": (foo, bar), "key_4": (foo, bar)}
+        ]
+
+
         # Optional w/ Defaults #
         assert arg_builder.TypeInherited.int_p_opt_def == 10
         assert arg_builder.TypeInherited.float_p_opt_def == 10.0
@@ -237,6 +270,13 @@ class AllInherited:
         assert arg_builder.TypeInherited.call_me_maybe_opt_def == foo
         assert arg_builder.TypeInherited.call_us_maybe_opt_def[0] == foo
         assert arg_builder.TypeInherited.call_us_maybe_opt_def[1] == foo
+
+        assert arg_builder.TypeInherited.str_dict_opt_def == {"key_1": 1.5, "key_2": 2.5}
+        assert arg_builder.TypeInherited.int_list_str_dict_opt_def == {"1": ['test', 'me'], "2": ['again', 'test']}
+        assert arg_builder.TypeInherited.float_tuple_callable_dict_opt_def == {"1.0": (foo, bar), "2.0": (foo, bar)}
+        assert arg_builder.TypeInherited.hardest_opt_def == [
+            {"key_1": (foo, bar), "key_2": (foo, bar)}, {"key_3": (foo, bar), "key_4": (foo, bar)}
+        ]
 
 
 class AllDynamic:

--- a/tests/base/test_cmd_line.py
+++ b/tests/base/test_cmd_line.py
@@ -81,7 +81,15 @@ class TestClassCmdLineOverride:
                     "--TypeConfig.call_me",
                     'tests.base.attr_configs_test.bar',
                     "--TypeConfig.call_us",
-                    "['tests.base.attr_configs_test.bar', 'tests.base.attr_configs_test.bar']"
+                    "['tests.base.attr_configs_test.bar', 'tests.base.attr_configs_test.bar']",
+                    "--TypeConfig.str_dict",
+                    "{'key_1': 2.5, 'key_2': 3.5}",
+                    "--TypeConfig.int_list_str_dict",
+                    "{'1': ['again', 'test'], '2': ['test', 'me']}",
+                    "--TypeConfig.float_tuple_callable_dict",
+                    '{"1.0": ("tests.base.attr_configs_test.bar", "tests.base.attr_configs_test.foo"), "2.0": ("tests.base.attr_configs_test.bar", "tests.base.attr_configs_test.foo")}',
+                    "--TypeConfig.hardest",
+                    '[{"key_1": ("tests.base.attr_configs_test.bar", "tests.base.attr_configs_test.foo"), "key_2": ("tests.base.attr_configs_test.bar", "tests.base.attr_configs_test.foo")}, {"key_3": ("tests.base.attr_configs_test.bar", "tests.base.attr_configs_test.foo"), "key_4": ("tests.base.attr_configs_test.bar", "tests.base.attr_configs_test.foo")}]'
                 ],
             )
             config = ConfigArgBuilder(
@@ -126,6 +134,11 @@ class TestClassCmdLineOverride:
         assert arg_builder.TypeConfig.call_me == bar
         assert arg_builder.TypeConfig.call_us[0] == bar
         assert arg_builder.TypeConfig.call_us[1] == bar
+        assert arg_builder.TypeConfig.str_dict == {"key_1": 2.5, "key_2": 3.5}
+        assert arg_builder.TypeConfig.int_list_str_dict == {"1": ['again', 'test'], "2": ['test', 'me']}
+        assert arg_builder.TypeConfig.float_tuple_callable_dict == {"1.0": (bar, foo), "2.0": (bar, foo)}
+        assert arg_builder.TypeConfig.hardest == [{"key_1": (bar, foo), "key_2": (bar, foo)},
+                                                  {"key_3": (bar, foo), "key_4": (bar, foo)}]
 
 
 class TestClassOnlyCmdLine:
@@ -198,7 +211,15 @@ class TestClassOnlyCmdLine:
                     "--TypeConfig.call_me",
                     'tests.base.attr_configs_test.foo',
                     "--TypeConfig.call_us",
-                    "['tests.base.attr_configs_test.foo', 'tests.base.attr_configs_test.foo']"
+                    "['tests.base.attr_configs_test.foo', 'tests.base.attr_configs_test.foo']",
+                    "--TypeConfig.str_dict",
+                    "{'key_1': 1.5, 'key_2': 2.5}",
+                    "--TypeConfig.int_list_str_dict",
+                    "{'1': ['test', 'me'], '2': ['again', 'test']}",
+                    "--TypeConfig.float_tuple_callable_dict",
+                    '{"1.0": ("tests.base.attr_configs_test.foo", "tests.base.attr_configs_test.bar"), "2.0": ("tests.base.attr_configs_test.foo", "tests.base.attr_configs_test.bar")}',
+                    "--TypeConfig.hardest",
+                    '[{"key_1": ("tests.base.attr_configs_test.foo", "tests.base.attr_configs_test.bar"), "key_2": ("tests.base.attr_configs_test.foo", "tests.base.attr_configs_test.bar")}, {"key_3": ("tests.base.attr_configs_test.foo", "tests.base.attr_configs_test.bar"), "key_4": ("tests.base.attr_configs_test.foo", "tests.base.attr_configs_test.bar")}]'
                 ],
             )
             config = ConfigArgBuilder(
@@ -245,6 +266,11 @@ class TestClassOnlyCmdLine:
         assert arg_builder.TypeConfig.call_me == foo
         assert arg_builder.TypeConfig.call_us[0] == foo
         assert arg_builder.TypeConfig.call_us[1] == foo
+        assert arg_builder.TypeConfig.str_dict == {"key_1": 1.5, "key_2": 2.5}
+        assert arg_builder.TypeConfig.int_list_str_dict == {"1": ['test', 'me'], "2": ['again', 'test']}
+        assert arg_builder.TypeConfig.float_tuple_callable_dict == {"1.0": (foo, bar), "2.0": (foo, bar)}
+        assert arg_builder.TypeConfig.hardest == [{"key_1": (foo, bar), "key_2": (foo, bar)},
+                                                  {"key_3": (foo, bar), "key_4": (foo, bar)}]
 
 
 class TestRaiseCmdLineNoKey:

--- a/tests/base/test_config_arg_builder.py
+++ b/tests/base/test_config_arg_builder.py
@@ -112,6 +112,22 @@ class TestNonAttrs:
                 return config.generate()
 
 
+class TestRaiseIncorrectKeyType:
+    def test_raises_missing_class(self, monkeypatch):
+        with monkeypatch.context() as m:
+            m.setattr(sys, "argv", ["", "--config", "./tests/conf/yaml/test_fail_dict_key.yaml"])
+            with pytest.raises(TypeError):
+                @spock
+                class FailDictKey:
+                    # Dict w/ int keys -- List of strings
+                    int_list_str_dict: Dict[int, List[str]]
+
+                config = ConfigArgBuilder(
+                    FailDictKey
+                )
+                return config.generate()
+
+
 class TestRaisesMissingClass:
     """Testing basic functionality"""
 

--- a/tests/conf/json/test.json
+++ b/tests/conf/json/test.json
@@ -48,5 +48,9 @@
     "float_p": 12.0
   },
   "call_me": "tests.base.attr_configs_test.foo",
-  "call_us": ["tests.base.attr_configs_test.foo", "tests.base.attr_configs_test.foo"]
+  "call_us": ["tests.base.attr_configs_test.foo", "tests.base.attr_configs_test.foo"],
+  "str_dict": {"key_1": 1.5, "key_2": 2.5},
+  "int_list_str_dict": {"1": ["test", "me"], "2": ["again", "test"]},
+  "float_tuple_callable_dict": {"1.0": ["tests.base.attr_configs_test.foo", "tests.base.attr_configs_test.bar"], "2.0": ["tests.base.attr_configs_test.foo", "tests.base.attr_configs_test.bar"]},
+  "hardest": [{"key_1": ["tests.base.attr_configs_test.foo", "tests.base.attr_configs_test.bar"], "key_2": ["tests.base.attr_configs_test.foo", "tests.base.attr_configs_test.bar"]}, {"key_3": ["tests.base.attr_configs_test.foo", "tests.base.attr_configs_test.bar"], "key_4": ["tests.base.attr_configs_test.foo", "tests.base.attr_configs_test.bar"]}]
 }

--- a/tests/conf/toml/test.toml
+++ b/tests/conf/toml/test.toml
@@ -60,3 +60,9 @@ high_config = 'SingleNestedConfig'
     float_p = 12.0
 call_me = 'tests.base.attr_configs_test.foo'
 call_us = ["tests.base.attr_configs_test.foo", "tests.base.attr_configs_test.foo"]
+
+
+str_dict = {key_1 = 1.5, key_2 = 2.5}
+int_list_str_dict = {"1" = ['test', 'me'], "2" = ['again', 'test']}
+float_tuple_callable_dict = {"1.0" = ["tests.base.attr_configs_test.foo", "tests.base.attr_configs_test.bar"], "2.0" = ["tests.base.attr_configs_test.foo", "tests.base.attr_configs_test.bar"]}
+hardest = [{key_1 = ["tests.base.attr_configs_test.foo", "tests.base.attr_configs_test.bar"], key_2 = ["tests.base.attr_configs_test.foo", "tests.base.attr_configs_test.bar"]}, {key_3 = ["tests.base.attr_configs_test.foo", "tests.base.attr_configs_test.bar"], key_4 = ["tests.base.attr_configs_test.foo", "tests.base.attr_configs_test.bar"]}]

--- a/tests/conf/yaml/inherited.yaml
+++ b/tests/conf/yaml/inherited.yaml
@@ -65,3 +65,21 @@ FirstDoubleNestedConfig:
   v_factor: 0.90
 call_me: "tests.base.attr_configs_test.foo"
 call_us: ["tests.base.attr_configs_test.foo", "tests.base.attr_configs_test.foo"]
+
+str_dict:
+  key_1: 1.5
+  key_2: 2.5
+
+int_list_str_dict:
+  "1": ['test', 'me']
+  "2": ['again', 'test']
+
+float_tuple_callable_dict:
+  "1.0": ["tests.base.attr_configs_test.foo", "tests.base.attr_configs_test.bar"]
+  "2.0": ["tests.base.attr_configs_test.foo", "tests.base.attr_configs_test.bar"]
+
+hardest:
+  - key_1: ["tests.base.attr_configs_test.foo", "tests.base.attr_configs_test.bar"]
+    key_2: ["tests.base.attr_configs_test.foo", "tests.base.attr_configs_test.bar"]
+  - key_3: ["tests.base.attr_configs_test.foo", "tests.base.attr_configs_test.bar"]
+    key_4: ["tests.base.attr_configs_test.foo", "tests.base.attr_configs_test.bar"]

--- a/tests/conf/yaml/test.yaml
+++ b/tests/conf/yaml/test.yaml
@@ -66,6 +66,25 @@ FirstDoubleNestedConfig:
 call_me: "tests.base.attr_configs_test.foo"
 call_us: ["tests.base.attr_configs_test.foo", "tests.base.attr_configs_test.foo"]
 
+str_dict:
+  key_1: 1.5
+  key_2: 2.5
+
+int_list_str_dict:
+  "1": ['test', 'me']
+  "2": ['again', 'test']
+
+float_tuple_callable_dict:
+  "1.0": ["tests.base.attr_configs_test.foo", "tests.base.attr_configs_test.bar"]
+  "2.0": ["tests.base.attr_configs_test.foo", "tests.base.attr_configs_test.bar"]
+
+hardest:
+  - key_1: ["tests.base.attr_configs_test.foo", "tests.base.attr_configs_test.bar"]
+    key_2: ["tests.base.attr_configs_test.foo", "tests.base.attr_configs_test.bar"]
+  - key_3: ["tests.base.attr_configs_test.foo", "tests.base.attr_configs_test.bar"]
+    key_4: ["tests.base.attr_configs_test.foo", "tests.base.attr_configs_test.bar"]
+
+
 # Override general definition
 TypeConfig:
     float_p: 12.0

--- a/tests/conf/yaml/test_class.yaml
+++ b/tests/conf/yaml/test_class.yaml
@@ -48,6 +48,27 @@ TypeConfig:
   # Class Enum
   class_enum: NestedListStuff
   high_config: SingleNestedConfig
+  call_me: "tests.base.attr_configs_test.foo"
+  call_us: ["tests.base.attr_configs_test.foo", "tests.base.attr_configs_test.foo"]
+
+  str_dict:
+    key_1: 1.5
+    key_2: 2.5
+
+  int_list_str_dict:
+    "1": ['test', 'me']
+    "2": ['again', 'test']
+
+  float_tuple_callable_dict:
+    "1.0": ["tests.base.attr_configs_test.foo", "tests.base.attr_configs_test.bar"]
+    "2.0": ["tests.base.attr_configs_test.foo", "tests.base.attr_configs_test.bar"]
+
+  hardest:
+    - key_1: ["tests.base.attr_configs_test.foo", "tests.base.attr_configs_test.bar"]
+      key_2: ["tests.base.attr_configs_test.foo", "tests.base.attr_configs_test.bar"]
+    - key_3: ["tests.base.attr_configs_test.foo", "tests.base.attr_configs_test.bar"]
+      key_4: ["tests.base.attr_configs_test.foo", "tests.base.attr_configs_test.bar"]
+
 SingleNestedConfig:
   double_nested_config: FirstDoubleNestedConfig
 FirstDoubleNestedConfig:
@@ -61,5 +82,3 @@ NestedListStuff:
 NestedStuff:
   one: 11
   two: ciao
-call_me: "tests.base.attr_configs_test.foo"
-call_us: ["tests.base.attr_configs_test.foo", "tests.base.attr_configs_test.foo"]

--- a/tests/conf/yaml/test_fail_dict_key.yaml
+++ b/tests/conf/yaml/test_fail_dict_key.yaml
@@ -1,0 +1,3 @@
+int_list_str_dict:
+  1: ['test', 'me']
+  2: ['again', 'test']

--- a/website/docs/advanced_features/Advanced-Types.md
+++ b/website/docs/advanced_features/Advanced-Types.md
@@ -1,17 +1,24 @@
 # Advanced Types
 
-`spock` also supports nested `List` or `Tuple` types and advanced argument types (such as repeated objects) that 
-use `Enum` or `@spock` decorated classes. All of the advanced types support the use of `Optional` and setting default 
-values. Example usage of advanced types can be found in the unittests 
+`spock` also supports nested `List`, `Tuple`, and `Dict` types and advanced argument types (such as repeated objects) 
+that use `Enum` or `@spock` decorated classes. All of the advanced types support the use of `Optional` and setting 
+default values. Example usage of advanced types can be found in the unittests 
 [here](https://github.com/fidelity/spock/tree/master/tests).
 
-### Nested List/Tuple Types
+### Nested List, Tuple, and Dict Types
+
+Some examples (not the full combinatorics space, but to illustrate what is possible) are:
 
 `List[List[int]]` -- Defines a list of list of integers.
 
-`List[List[str]]` -- Defines a list of list of strings.
+`List[List[Callable]]` -- Defines a list of list of callable objects.
 
-### Lists/Tuples of `Enum`
+`Tuple[List[str], List[str]]` -- Defines a two length tuple of lists of strings.
+
+`Dict[str, List[str]]` -- Defines a dictionary where keys are strings and values must be lists of strings
+
+
+### Lists and Tuple of `Enum`
 
 ```python
 from enum import Enum
@@ -34,7 +41,7 @@ With YAML definitions:
 list_choice_p_str: ['option_1', 'option_2']
 ```
 
-### List/Tuple of Repeated `@spock` Classes 
+### List and Tuple of Repeated `@spock` Classes 
 
 These can be accessed by index and are iterable.
 

--- a/website/docs/advanced_features/Evolve.md
+++ b/website/docs/advanced_features/Evolve.md
@@ -9,7 +9,7 @@
 
 The `evolve()` method is available form the `SpockBuilder` object. `evolve()` takes as input a variable number of 
 instantiated `@spock` decorated classes, evolves the underlying `attrs` objects to incorporate the changes between
-the instantiated classes and the underlying classes, and returns the new `Spocksspace` object.
+the instantiated classes and the underlying classes, and returns the new `Spockspace` object.
 
 For instance:
 
@@ -40,7 +40,7 @@ if __name__ == '__main__':
     main()
 ```
 
-This would evolve the value of `param` to be 10 instead of the defulat value of 10. The print output woulf be:
+This would evolve the value of `param` to be 20 instead of the default value of 10. The print output would be:
 
 ```shell
 Configs4OneThing: !!python/object:spock.backend.config.Configs4OneThing

--- a/website/docs/advanced_features/Post-Hooks.md
+++ b/website/docs/advanced_features/Post-Hooks.md
@@ -1,0 +1,50 @@
+# Post Initialization Hooks
+
+`spock` supports post initialization (post-init) hooks via the `__post_hook__` method within a `@spock` decorated class.
+These methods are automatically called after the `Spockspace` object is created thus allow the user to do any post
+instantiation work (such as validation).
+
+### Creating and Using Post-Init Hooks
+
+Simply add the `__post_hook__` method to your `@spock` decorated class:
+
+```python
+from spock import spock
+from spock.utils import within, ge
+from typing import List
+
+
+def my_post_init_hook(list_vals: List[float], sum_val: float):
+    if sum(list_vals) != sum_val:
+        raise ValueError(f"Sum of `{sum(list_vals)}` does not equal 1.0")
+
+
+@spock
+class PostInitExample:
+    list_vals: List[float] = [0.5, 0.25, 0.25]
+    check_sum: float = 1.0
+    my_value: float = 1.2
+    other: float = 0.1
+    lower_bound: float = 0.0
+    
+    def __post_hook__(self):
+        # Validate that value is between 0.0 and 1.0 (inclusive)
+        within(self.my_value, low_bound=0.0, upper_bound=1.0, inclusive_lower=True, inclusive_upper=True)
+        # Validate that other is greater than lower_bound
+        ge(self.other, bound=self.lower_bound)
+        my_post_init_hook(self.list_vals, self.check_sum)
+```
+
+The `__post_hook__` method will be triggered post instantiation. Therefore, the example above will throw an `Exception` 
+since the value of `my_value` does not fall within the given bounds. Also notice that you can reference other defined
+parameters within the `__post_hook__` methods and use them in custom functions (here we use `lower_bound` and 
+`check_sum` to do some validation comparisons)
+
+### Common Post Initialization Hooks
+
+`spock` provides some common validators (in the `utils` module) that would be typically run as post-init 
+hooks including: greater than (`gt`), greater than or equals to (`ge`), less than (`lt`), less than or equals to (`le`),
+and if a parameter falls within a set of inclusive/exclusive bounds (`within`).
+
+
+

--- a/website/docs/basics/Define.md
+++ b/website/docs/basics/Define.md
@@ -13,16 +13,18 @@ All examples can be found [here](https://github.com/fidelity/spock/blob/master/e
 `spock` supports the following basic argument types (note `List`, `Tuple`, and `Optional` are defined in the `typing` 
 standard library while `Enum` is within the `enum` standard library):
 
-| Python Base or Typing Type (Required) | Optional Type | Description |
-|----------------------------|---------------|-------------|
-| bool | Optional[bool] | Basic boolean parameter (e.g. True) |
-| float | Optional[float] | Basic float type parameter (e.g. 10.2) |
-| int | Optional[int] | Basic integer type parameter (e.g. 2) |
-| str | Optional[str] | Basic string type parameter (e.g. 'foo') |
-| List[type] | Optional[List[type]] | Basic list type parameter of base types such as int, float, etc. (e.g. [10.0, 2.0]) |
-| Tuple[type] | Optional[Tuple[type]] | Basic tuple type parameter of base types such as int, float, etc. Length enforced unlike List. (e.g. (10, 2)) |
-| Enum | Optional[Enum] | Parameter that must be from a defined set of values of base types such as int, float, etc. |
-| @spock decorated Class | Optional[Class] | Parameter that is a reference to another @spock decorated class |
+| Python Base or Typing Type (Required) | Optional Type         | Description                                                                                                   |
+|---------------------------------------|-----------------------|---------------------------------------------------------------------------------------------------------------|
+| bool                                  | Optional[bool]        | Basic boolean parameter (e.g. True)                                                                           |
+| float                                 | Optional[float]       | Basic float type parameter (e.g. 10.2)                                                                        |
+| int                                   | Optional[int]         | Basic integer type parameter (e.g. 2)                                                                         |
+| str                                   | Optional[str]         | Basic string type parameter (e.g. 'foo')                                                                      |
+| Callable                              | Optional[Callable]    | Any callable type (e.g. my_func)                                                                              |
+| List[type]                            | Optional[List[type]]  | Basic list type parameter of base types such as int, float, etc. (e.g. [10.0, 2.0])                           |
+| Tuple[type]                           | Optional[Tuple[type]] | Basic tuple type parameter of base types such as int, float, etc. Length enforced unlike List. (e.g. (10, 2)) |
+| Dict[type]                            | Optional[Dict[type]]  | Basic dict type parameter where both key (str only for valid TOML/JSON) and value types are specified         |
+| Enum                                  | Optional[Enum]        | Parameter that must be from a defined set of values of base types such as int, float, etc.                    |
+| @spock decorated Class                | Optional[Class]       | Parameter that is a reference to another @spock decorated class                                               |
 
 Use `List` types when the length of the `Iterable` is not fixed and `Tuple` when length needs to be strictly enforced.
 

--- a/website/docs/index.md
+++ b/website/docs/index.md
@@ -11,12 +11,16 @@ title: Home
 <p align="center">
   <a href="https://opensource.org/licenses/Apache-2.0"><img src="https://img.shields.io/badge/License-Apache%202.0-9cf"/></a>
   <a href="https://bestpractices.coreinfrastructure.org/projects/5551"><img src="https://bestpractices.coreinfrastructure.org/projects/5551/badge"/></a>
+  <a><img src="https://github.com/fidelity/spock/workflows/pytest/badge.svg?branch=master"/></a>
+<a href="https://coveralls.io/github/fidelity/spock?branch=master"><img src="https://coveralls.io/repos/github/fidelity/spock/badge.svg?branch=master"/></a>
+  <a><img src="https://github.com/fidelity/spock/workflows/docs/badge.svg"/></a>
+</p>
+
+<p align="center">
   <a><img src="https://img.shields.io/badge/python-3.6+-informational.svg"/></a>
   <a href="https://github.com/psf/black"><img src="https://img.shields.io/badge/code%20style-black-000000.svg"/></a>
   <a href="https://badge.fury.io/py/spock-config"><img src="https://badge.fury.io/py/spock-config.svg"/></a>
-  <a href="https://coveralls.io/github/fidelity/spock?branch=master"><img src="https://coveralls.io/repos/github/fidelity/spock/badge.svg?branch=master"/></a>
-  <a><img src="https://github.com/fidelity/spock/workflows/pytest/badge.svg?branch=master"/></a>
-  <a><img src="https://github.com/fidelity/spock/workflows/docs/badge.svg"/></a>
+  <a href="https://pepy.tech/badge/spock-config"><img src="https://static.pepy.tech/personalized-badge/spock-config?period=total&units=international_system&left_color=grey&right_color=orange&left_text=Downloads"/></a>
 </p>
   
 <h3 align="center">
@@ -101,9 +105,17 @@ See [Releases](https://github.com/fidelity/spock/releases) for more information.
 
 
 
+#### March 17th, 2022
+* Added support for `typing.Callable` types (includes advanced types such as `List[List[Callable]]`)
+* Added support for `typing.Dict` types with type checking for types of both keys and values (includes advanced types
+such as `Dict[str, Tuple[Callable, Callable]]`)
+* Added support for post init hooks that allow for validation on parameters defined within `@spock` decorated classes. 
+Additionally, added some common validation check to utils (within, greater than, less than, etc.)
+* Updated unit tests to support Python 3.10
+
 #### January 26th, 2022
 * Added `evolve` support to the underlying `SpockBuilder` class. This provides functionality similar to the underlying
-attrs library ([attrs.evolve](https://www.attrs.org/en/stable/api.html#attrs.evolve). `evolve()` creates a new 
+attrs library ([attrs.evolve](https://www.attrs.org/en/stable/api.html#attrs.evolve)). `evolve()` creates a new 
 `Spockspace` instance based on differences between the underlying declared state and any passed in instantiated 
 `@spock` decorated classes.
 
@@ -114,12 +126,6 @@ passed into `*args` within the main `SpockBuilder` API
 * Updated main API interface for better top-level imports (backwards compatible): `ConfigArgBuilder`->`SpockBuilder`
 * Added stubs to the underlying decorator that should help with type hinting in VSCode (pylance/pyright)
 
-#### December 14, 2021
-* Refactored the backend to better handle nested dependencies (and for clarity)
-* Refactored the docs to use Docusaurus
-
-#### August 17, 2021
-* Added hyper-parameter tuning backend support for Ax via Service API
 
 
 ## Original Implementation

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -96,6 +96,11 @@ module.exports = {
                 },
                 {
                     type: 'doc',
+                    label: 'Post-Init Hooks',
+                    id: 'advanced_features/Post-Hooks'
+                },
+                {
+                    type: 'doc',
                     label: 'Lazy Dependencies',
                     id: "advanced_features/Lazy-Features"
                 },


### PR DESCRIPTION
## What does this PR do?
Added support for `typing.Dict` types with type checking for types of both keys and values (includes advanced types
such as `Dict[str, Tuple[Callable, Callable]]`)

## Checklist
  - [x] Did you adhere to [PEP-8](https://www.python.org/dev/peps/pep-0008/) standards?
  - [x] Did you run black and isort prior to submitting your PR? 
  - [x] Does your PR pass all existing unit tests?
  - [x] Did you add associated unit tests for any additional functionality?
  - [x] Did you provide documentation ([Google Docstring format](https://google.github.io/styleguide/pyguide.html)) whenever possible, even for simple functions or classes?