### PR TITLE
Convert spock class (or iterable) to dictionary format

### DIFF
--- a/tests/base/test_evolve.py
+++ b/tests/base/test_evolve.py
@@ -172,3 +172,6 @@ class TestEvolve:
         # Evolve the class
         new_class = arg_builder.evolve(evolve_nested_stuff, evolve_type_config)
         assert isinstance(arg_builder.spockspace_2_dict(new_class), dict) is True
+
+
+


### PR DESCRIPTION
## What does this PR do?
added method that converts a spock class or iterable of spock classes to a dictionary

## Checklist
  - [x] Did you adhere to [PEP-8](https://www.python.org/dev/peps/pep-0008/) standards?
  - [x] Did you run black and isort prior to submitting your PR? 
  - [x] Does your PR pass all existing unit tests?
  - [x] Did you add associated unit tests for any additional functionality?
  - [x] Did you provide documentation ([Google Docstring format](https://google.github.io/styleguide/pyguide.html)) whenever possible, even for simple functions or classes?