### PR TITLE
Environment Variable Resolver

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -23,16 +23,10 @@ A clear and concise description of what you expected to happen.
 **Screenshots**
 If applicable, add screenshots to help explain your problem.
 
-**Desktop (please complete the following information):**
- - OS: [e.g. iOS]
- - Browser [e.g. chrome, safari]
- - Version [e.g. 22]
-
-**Smartphone (please complete the following information):**
- - Device: [e.g. iPhone6]
- - OS: [e.g. iOS8.1]
- - Browser [e.g. stock browser, safari]
- - Version [e.g. 22]
+**Environment (please complete the following information):**
+- OS: [e.g. Ubuntu 16.04, Windows, etc.]
+- Python version [e.g. 3.6.3, 3.7.5]:
+- Other installed packages [e.g. torch, scipy, etc.]
 
 **Additional context**
 Add any other context about the problem here.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,7 +12,8 @@ E.g. Describe the added feature or what issue it fixes #(issue)...
   - [ ] Did you run black and isort prior to submitting your PR? 
   - [ ] Does your PR pass all existing unit tests?
   - [ ] Did you add associated unit tests for any additional functionality?
-  - [ ] Did you provide documentation ([Google Docstring format](https://google.github.io/styleguide/pyguide.html)) whenever possible, even for simple functions or classes?
+  - [ ] Did you provide code documentation ([Google Docstring format](https://google.github.io/styleguide/pyguide.html)) whenever possible, even for simple functions or classes?
+  - [ ] Did you add necessary documentation to the website?
 
 ## Review
 Request will go to reviewers to approve for merge.

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -11,9 +11,11 @@ FMR LLC (https://www.fidelity.com/).
 
 This product relies on the following works (and the dependencies thereof), installed separately:
 - attrs | https://github.com/python-attrs/attrs | MIT License
+- cryptography | https://github.com/pyca/cryptography | Apache License 2.0 + BSD License
 - GitPython | https://github.com/gitpython-developers/GitPython | BSD 3-Clause License
 - pytomlpp | https://github.com/bobfang1992/pytomlpp | MIT License
 - PyYAML | https://github.com/yaml/pyyaml | MIT License
+- setuptools | https://github.com/pypa/setuptools | MIT License
 
 
 Optional extensions rely on the following works (and the dependencies thereof), installed separately:

--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ generating CLI arguments, and hierarchical configuration by composition.
 * Automatic type checked CLI generation w/o argparser boilerplate (i.e click and/or typer for free!)
 * Easily maintain parity between CLIs and Python APIs (i.e. single line changes between CLI and Python API definitions)
 * Unified hyper-parameter definitions and interface (i.e. don't write different definitions for Ax or Optuna)
+* Resolver that supports value definitions from environmental variables, dynamic template re-injection, and 
+encryption of sensitive values
 
 ## Key Features
 
@@ -100,6 +102,13 @@ See [Releases](https://github.com/fidelity/spock/releases) for more information.
 </html>
 
 <details>
+
+#### May 17th, 2022
+* Added support for resolving value definitions from environmental variables with the following syntax, 
+`${spock.env:name, default}`
+* Added `.inject` annotation that will write back the original env notation to the saved output
+* Added the `.crypto` annotation which provides a simple way to hide sensitive environmental
+variables while still maintaining the written/loadable state of the spock config
 
 #### March 17th, 2022
 * Added support for `typing.Callable` types (includes advanced types such as `List[List[Callable]]`)

--- a/REQUIREMENTS.txt
+++ b/REQUIREMENTS.txt
@@ -1,4 +1,6 @@
 attrs~=21.4
+cryptography~=37.0
 GitPython~=3.1
 pytomlpp~=1.0
 pyYAML~=5.4
+setuptools~=59.6

--- a/spock/addons/tune/payload.py
+++ b/spock/addons/tune/payload.py
@@ -6,7 +6,9 @@
 """Handles the tuner payload backend"""
 
 from spock.backend.payload import BasePayload
-from spock.backend.utils import get_attr_fields
+from spock.backend.utils import get_attr_fields, _T
+
+from typing import Optional
 
 
 class TunerPayload(BasePayload):
@@ -20,7 +22,7 @@ class TunerPayload(BasePayload):
 
     """
 
-    def __init__(self, s3_config=None):
+    def __init__(self, s3_config: Optional[_T] = None):
         """Init for TunerPayload
 
         Args:

--- a/spock/addons/tune/payload.py
+++ b/spock/addons/tune/payload.py
@@ -5,10 +5,10 @@
 
 """Handles the tuner payload backend"""
 
-from spock.backend.payload import BasePayload
-from spock.backend.utils import get_attr_fields, _T
-
 from typing import Optional
+
+from spock.backend.payload import BasePayload
+from spock.backend.utils import _T, get_attr_fields
 
 
 class TunerPayload(BasePayload):

--- a/spock/backend/field_handlers.py
+++ b/spock/backend/field_handlers.py
@@ -13,6 +13,7 @@ from typing import Callable, Dict, List, Tuple, Type
 
 from attr import NOTHING, Attribute
 
+from spock.backend.resolvers import parse_env_variables
 from spock.backend.spaces import AttributeSpace, BuilderSpace, ConfigSpace
 from spock.backend.utils import (
     _get_name_py_version,
@@ -132,7 +133,8 @@ class RegisterFieldTemplate(ABC):
 
         Returns:
         """
-        attr_space.field = attr_space.attribute.default
+        cleaned_attribute = parse_env_variables(attr_space.attribute.default, attr_space.attribute.type)
+        attr_space.field = cleaned_attribute
 
     @abstractmethod
     def handle_optional_attribute_type(

--- a/spock/backend/field_handlers.py
+++ b/spock/backend/field_handlers.py
@@ -155,7 +155,6 @@ class RegisterFieldTemplate(ABC):
             self._handle_crypto_annotations(
                 attr_space, crypto_annotation, attr_space.attribute.default
             )
-            attr_space.crypto = True
         attr_space.field = value
 
     def _handle_env_annotations(
@@ -166,6 +165,7 @@ class RegisterFieldTemplate(ABC):
             attr_space.annotations = (
                 f"${{spock.crypto:{encrypt_value(str(value), self._key, self._salt)}}}"
             )
+            attr_space.crypto = True
         elif annotation == "inject":
             attr_space.annotations = og_value
         else:
@@ -177,6 +177,7 @@ class RegisterFieldTemplate(ABC):
     ):
         if annotation == "crypto":
             attr_space.annotations = og_value
+            attr_space.crypto = True
         else:
             raise _SpockInstantiationError(
                 f"Got unknown crypto annotation `{annotation}`"

--- a/spock/backend/field_handlers.py
+++ b/spock/backend/field_handlers.py
@@ -155,6 +155,7 @@ class RegisterFieldTemplate(ABC):
             self._handle_crypto_annotations(
                 attr_space, crypto_annotation, attr_space.attribute.default
             )
+            attr_space.crypto = True
         attr_space.field = value
 
     def _handle_env_annotations(
@@ -537,6 +538,7 @@ class RegisterSimpleField(RegisterFieldTemplate):
         )
         if crypto_annotation is not None:
             self._handle_crypto_annotations(attr_space, crypto_annotation, og_value)
+            attr_space.crypto = True
         attr_space.field = value
         self.register_special_key(attr_space)
 
@@ -815,6 +817,7 @@ class RegisterSpockCls(RegisterFieldTemplate):
         special_keys = {}
         fields = {}
         annotations = {}
+        crypto = False
         # Init the ConfigSpace for this spock class
         config_space = ConfigSpace(spock_cls, fields)
         # Iterate through the attrs within the spock class
@@ -860,6 +863,8 @@ class RegisterSpockCls(RegisterFieldTemplate):
             # Handle annotations by attaching them to a dictionary
             if attr_space.annotations is not None:
                 annotations.update({attr_space.attribute.name: attr_space.annotations})
+            if attr_space.crypto:
+                crypto = True
 
         # Try except on the class since it might not be successful -- throw the attrs message as it will know the
         # error on instantiation
@@ -867,6 +872,8 @@ class RegisterSpockCls(RegisterFieldTemplate):
             # If there are annotations attach them to the spock class in the __resolver__ attribute
             if len(annotations) > 0:
                 spock_cls.__resolver__ = annotations
+            if crypto:
+                spock_cls.__crypto__ = True
             spock_instance = spock_cls(**fields)
         except Exception as e:
             raise _SpockInstantiationError(

--- a/spock/backend/field_handlers.py
+++ b/spock/backend/field_handlers.py
@@ -9,16 +9,17 @@ import importlib
 import sys
 from abc import ABC, abstractmethod
 from enum import EnumMeta
-from typing import Callable, Dict, List, Tuple, Type
+from typing import Any, ByteString, Callable, Dict, List, Tuple, Type
 
 from attr import NOTHING, Attribute
 
-from spock.backend.resolvers import parse_env_variables
+from spock.backend.resolvers import CryptoResolver, EnvResolver
 from spock.backend.spaces import AttributeSpace, BuilderSpace, ConfigSpace
 from spock.backend.utils import (
     _get_name_py_version,
     _recurse_callables,
     _str_2_callable,
+    encrypt_value,
 )
 from spock.exceptions import _SpockInstantiationError, _SpockNotOptionalError
 from spock.utils import (
@@ -45,12 +46,16 @@ class RegisterFieldTemplate(ABC):
 
     """
 
-    def __init__(self):
+    def __init__(self, salt: str, key: ByteString):
         """Init call for RegisterFieldTemplate class
 
         Args:
         """
         self.special_keys = {}
+        self._salt = salt
+        self._key = key
+        self._env_resolver = EnvResolver()
+        self._crypto_resolver = CryptoResolver(self._salt, self._key)
 
     def __call__(self, attr_space: AttributeSpace, builder_space: BuilderSpace):
         """Call method for RegisterFieldTemplate
@@ -93,8 +98,10 @@ class RegisterFieldTemplate(ABC):
             _is_spock_instance(attr_space.attribute.type)
             and attr_space.attribute.default is not None
         ):
-            attr_space.field, special_keys = RegisterSpockCls().recurse_generate(
-                attr_space.attribute.type, builder_space
+            attr_space.field, special_keys = RegisterSpockCls(
+                self._salt, self._key
+            ).recurse_generate(
+                attr_space.attribute.type, builder_space, self._salt, self._key
             )
             attr_space.attribute = attr_space.attribute.evolve(default=attr_space.field)
             builder_space.spock_space[
@@ -133,8 +140,46 @@ class RegisterFieldTemplate(ABC):
 
         Returns:
         """
-        cleaned_attribute = parse_env_variables(attr_space.attribute.default, attr_space.attribute.type)
-        attr_space.field = cleaned_attribute
+
+        value, env_annotation = self._env_resolver.resolve(
+            attr_space.attribute.default, attr_space.attribute.type
+        )
+        if env_annotation is not None:
+            self._handle_env_annotations(
+                attr_space, env_annotation, value, attr_space.attribute.default
+            )
+        value, crypto_annotation = self._crypto_resolver.resolve(
+            value, attr_space.attribute.type
+        )
+        if crypto_annotation is not None:
+            self._handle_crypto_annotations(
+                attr_space, crypto_annotation, attr_space.attribute.default
+            )
+        attr_space.field = value
+
+    def _handle_env_annotations(
+        self, attr_space: AttributeSpace, annotation: str, value: Any, og_value: Any
+    ):
+        if annotation == "crypto":
+            # Take the current value to string and then encrypt
+            attr_space.annotations = (
+                f"${{spock.crypto:{encrypt_value(str(value), self._key, self._salt)}}}"
+            )
+        elif annotation == "inject":
+            attr_space.annotations = og_value
+        else:
+            raise _SpockInstantiationError(f"Got unknown env annotation `{annotation}`")
+
+    @staticmethod
+    def _handle_crypto_annotations(
+        attr_space: AttributeSpace, annotation: str, og_value: str
+    ):
+        if annotation == "crypto":
+            attr_space.annotations = og_value
+        else:
+            raise _SpockInstantiationError(
+                f"Got unknown crypto annotation `{annotation}`"
+            )
 
     @abstractmethod
     def handle_optional_attribute_type(
@@ -157,12 +202,12 @@ class RegisterList(RegisterFieldTemplate):
 
     """
 
-    def __init__(self):
+    def __init__(self, salt: str, key: ByteString):
         """Init call to RegisterList
 
         Args:
         """
-        super(RegisterList, self).__init__()
+        super(RegisterList, self).__init__(salt, key)
 
     def handle_attribute_from_config(
         self, attr_space: AttributeSpace, builder_space: BuilderSpace
@@ -255,12 +300,12 @@ class RegisterEnum(RegisterFieldTemplate):
 
     """
 
-    def __init__(self):
+    def __init__(self, salt: str, key: ByteString):
         """Init call to RegisterEnum
 
         Args:
         """
-        super(RegisterEnum, self).__init__()
+        super(RegisterEnum, self).__init__(salt, key)
 
     def handle_attribute_from_config(
         self, attr_space: AttributeSpace, builder_space: BuilderSpace
@@ -327,7 +372,7 @@ class RegisterEnum(RegisterFieldTemplate):
         Returns:
         """
         attr_space.field, special_keys = RegisterSpockCls.recurse_generate(
-            enum_cls, builder_space
+            enum_cls, builder_space, self._salt, self._key
         )
         self.special_keys.update(special_keys)
         builder_space.spock_space[enum_cls.__name__] = attr_space.field
@@ -341,12 +386,12 @@ class RegisterCallableField(RegisterFieldTemplate):
 
     """
 
-    def __init__(self):
+    def __init__(self, salt: str, key: ByteString):
         """Init call to RegisterSimpleField
 
         Args:
         """
-        super(RegisterCallableField, self).__init__()
+        super(RegisterCallableField, self).__init__(salt, key)
 
     def handle_attribute_from_config(
         self, attr_space: AttributeSpace, builder_space: BuilderSpace
@@ -394,12 +439,12 @@ class RegisterGenericAliasCallableField(RegisterFieldTemplate):
 
     """
 
-    def __init__(self):
+    def __init__(self, salt: str, key: ByteString):
         """Init call to RegisterSimpleField
 
         Args:
         """
-        super(RegisterGenericAliasCallableField, self).__init__()
+        super(RegisterGenericAliasCallableField, self).__init__(salt, key)
 
     def handle_attribute_from_config(
         self, attr_space: AttributeSpace, builder_space: BuilderSpace
@@ -461,17 +506,17 @@ class RegisterSimpleField(RegisterFieldTemplate):
 
     """
 
-    def __init__(self):
+    def __init__(self, salt: str, key: ByteString):
         """Init call to RegisterSimpleField
 
         Args:
         """
-        super(RegisterSimpleField, self).__init__()
+        super(RegisterSimpleField, self).__init__(salt, key)
 
     def handle_attribute_from_config(
         self, attr_space: AttributeSpace, builder_space: BuilderSpace
     ):
-        """Handles setting a simple attribute when it is a spock class type
+        """Handles setting a simple attribute from a config file
 
         Args:
             attr_space: holds information about a single attribute that is mapped to a ConfigSpace
@@ -479,9 +524,20 @@ class RegisterSimpleField(RegisterFieldTemplate):
 
         Returns:
         """
-        attr_space.field = builder_space.arguments[attr_space.config_space.name][
+        og_value = builder_space.arguments[attr_space.config_space.name][
             attr_space.attribute.name
         ]
+        value, env_annotation = self._env_resolver.resolve(
+            og_value, attr_space.attribute.type
+        )
+        if env_annotation is not None:
+            self._handle_env_annotations(attr_space, env_annotation, value, og_value)
+        value, crypto_annotation = self._crypto_resolver.resolve(
+            value, attr_space.attribute.type
+        )
+        if crypto_annotation is not None:
+            self._handle_crypto_annotations(attr_space, crypto_annotation, og_value)
+        attr_space.field = value
         self.register_special_key(attr_space)
 
     def handle_optional_attribute_type(
@@ -543,12 +599,12 @@ class RegisterTuneCls(RegisterFieldTemplate):
 
     """
 
-    def __init__(self):
+    def __init__(self, salt: str, key: ByteString):
         """Init call to RegisterTuneCls
 
         Args:
         """
-        super(RegisterTuneCls, self).__init__()
+        super(RegisterTuneCls, self).__init__(salt, key)
 
     @staticmethod
     def _attr_type(attr_space: AttributeSpace):
@@ -622,12 +678,12 @@ class RegisterSpockCls(RegisterFieldTemplate):
 
     """
 
-    def __init__(self):
+    def __init__(self, salt: str, key: ByteString):
         """Init call to RegisterSpockCls
 
         Args:
         """
-        super(RegisterSpockCls, self).__init__()
+        super(RegisterSpockCls, self).__init__(salt, key)
 
     @staticmethod
     def _attr_type(attr_space: AttributeSpace):
@@ -656,7 +712,9 @@ class RegisterSpockCls(RegisterFieldTemplate):
         Returns:
         """
         attr_type = self._attr_type(attr_space)
-        attr_space.field, special_keys = self.recurse_generate(attr_type, builder_space)
+        attr_space.field, special_keys = self.recurse_generate(
+            attr_type, builder_space, self._salt, self._key
+        )
         builder_space.spock_space[attr_type.__name__] = attr_space.field
         self.special_keys.update(special_keys)
 
@@ -694,7 +752,7 @@ class RegisterSpockCls(RegisterFieldTemplate):
         Returns:
         """
         attr_space.field, special_keys = RegisterSpockCls.recurse_generate(
-            self._attr_type(attr_space), builder_space
+            self._attr_type(attr_space), builder_space, self._salt, self._key
         )
         self.special_keys.update(special_keys)
 
@@ -738,7 +796,9 @@ class RegisterSpockCls(RegisterFieldTemplate):
         return out
 
     @classmethod
-    def recurse_generate(cls, spock_cls: _C, builder_space: BuilderSpace):
+    def recurse_generate(
+        cls, spock_cls: _C, builder_space: BuilderSpace, salt: str, key: ByteString
+    ):
         """Call on a spock classes to iterate through the attrs attributes and handle each based on type and optionality
 
         Triggers a recursive call when an attribute refers to another spock classes
@@ -754,6 +814,7 @@ class RegisterSpockCls(RegisterFieldTemplate):
         # Empty dits for storing info
         special_keys = {}
         fields = {}
+        annotations = {}
         # Init the ConfigSpace for this spock class
         config_space = ConfigSpace(spock_cls, fields)
         # Iterate through the attrs within the spock class
@@ -764,7 +825,7 @@ class RegisterSpockCls(RegisterFieldTemplate):
             if (
                 (attribute.type is list) or (attribute.type is List)
             ) and _is_spock_instance(attribute.metadata["type"].__args__[0]):
-                handler = RegisterList()
+                handler = RegisterList(salt, key)
             # Dict/List of Callables
             elif (
                 (attribute.type is list)
@@ -775,31 +836,37 @@ class RegisterSpockCls(RegisterFieldTemplate):
                 or (attribute.type is Tuple)
             ) and cls._find_callables(attribute.metadata["type"]):
                 # handler = RegisterListCallableField()
-                handler = RegisterGenericAliasCallableField()
+                handler = RegisterGenericAliasCallableField(salt, key)
             # Enums
             elif isinstance(attribute.type, EnumMeta) and _check_iterable(
                 attribute.type
             ):
-                handler = RegisterEnum()
+                handler = RegisterEnum(salt, key)
             # References to other spock classes
             elif _is_spock_instance(attribute.type):
-                handler = RegisterSpockCls()
+                handler = RegisterSpockCls(salt, key)
             # References to tuner classes
             elif _is_spock_tune_instance(attribute.type):
-                handler = RegisterTuneCls()
+                handler = RegisterTuneCls(salt, key)
             # References to callables
             elif isinstance(attribute.type, _SpockVariadicGenericAlias):
-                handler = RegisterCallableField()
+                handler = RegisterCallableField(salt, key)
             # Basic field
             else:
-                handler = RegisterSimpleField()
+                handler = RegisterSimpleField(salt, key)
 
             handler(attr_space, builder_space)
             special_keys.update(handler.special_keys)
+            # Handle annotations by attaching them to a dictionary
+            if attr_space.annotations is not None:
+                annotations.update({attr_space.attribute.name: attr_space.annotations})
 
         # Try except on the class since it might not be successful -- throw the attrs message as it will know the
         # error on instantiation
         try:
+            # If there are annotations attach them to the spock class in the __resolver__ attribute
+            if len(annotations) > 0:
+                spock_cls.__resolver__ = annotations
             spock_instance = spock_cls(**fields)
         except Exception as e:
             raise _SpockInstantiationError(

--- a/spock/backend/resolvers.py
+++ b/spock/backend/resolvers.py
@@ -7,7 +7,7 @@
 import os
 import re
 from abc import ABC, abstractmethod
-from typing import Any, ByteString, Optional, Tuple, Pattern, Union
+from typing import Any, ByteString, Optional, Pattern, Tuple, Union
 
 from spock.backend.utils import decrypt_value
 from spock.exceptions import _SpockResolverError
@@ -23,6 +23,7 @@ class BaseResolver(ABC):
         _annotation_set: current set of supported resolver annotations
 
     """
+
     def __init__(self):
         """Init for BaseResolver class"""
         self._annotation_set = {"crypto", "inject"}
@@ -186,6 +187,7 @@ class EnvResolver(BaseResolver):
         FULL_REGEX_OP: compiled regex for full regex
 
     """
+
     # ENV Resolver -- full regex is ^\${spock\.env\.?([a-z]*?):.*}$
     CLIP_ENV_PATTERN = r"^\${spock\.env\.?([a-z]*?):"
     CLIP_REGEX_OP = re.compile(CLIP_ENV_PATTERN)
@@ -195,7 +197,7 @@ class EnvResolver(BaseResolver):
     FULL_REGEX_OP = re.compile(FULL_ENV_PATTERN)
 
     def __init__(self):
-        """Init for EnvResolver """
+        """Init for EnvResolver"""
         super(EnvResolver, self).__init__()
 
     def resolve(self, value: Any, value_type: _T) -> Tuple[Any, Optional[str]]:
@@ -264,6 +266,7 @@ class CryptoResolver(BaseResolver):
         _key: current cryptographic key
 
     """
+
     # ENV Resolver -- full regex is ^\${spock\.crypto:.*}$
     CLIP_ENV_PATTERN = r"^\${spock\.crypto:"
     CLIP_REGEX_OP = re.compile(CLIP_ENV_PATTERN)

--- a/spock/backend/resolvers.py
+++ b/spock/backend/resolvers.py
@@ -1,0 +1,90 @@
+# -*- coding: utf-8 -*-
+
+# Copyright FMR LLC <opensource@fidelity.com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Resolver functions for Spock"""
+
+import re
+import os
+from typing import Any
+
+from spock.exceptions import _SpockEnvResolverError
+from spock.utils import _T
+
+
+# ENV Resolver -- full regex is ^\${spock\.env:.*}$
+CLIP_ENV_PATTERN = r"^\${spock\.env:"
+CLIP_REGEX_OP = re.compile(CLIP_ENV_PATTERN)
+END_ENV_PATTERN = r"}$"
+END_REGEX_OP = re.compile(END_ENV_PATTERN)
+FULL_ENV_PATTERN = CLIP_ENV_PATTERN + r".*" + END_ENV_PATTERN
+FULL_REGEX_OP = re.compile(FULL_ENV_PATTERN)
+
+
+def parse_env_variables(value: Any, value_type: _T) -> Any:
+    # Check if it matches the regex
+    # if so then split and replace with the value from the env -- have to check here if the env variable actually
+    # exists -- if it doesn't then we need to raise an exception -- allow for None?
+
+    # If it's a string we can check the regex
+    if isinstance(value, str):
+        # Check the regex
+        match_obj = FULL_REGEX_OP.fullmatch(value)
+        # if the object exists then we've matched a pattern and need to handle it
+        if match_obj is not None:
+            return _get_env_value(value, value_type)
+        # Regex doesn't match so just passthrough
+        else:
+            return value
+    # If it's not a string we can't resolve anything so just passthrough and let spock handle the value
+    else:
+        return value
+
+
+def _handle_default(value: str):
+    env_value, default_value = value.split(',')
+    default_value = default_value.strip()
+    # Swap string None to type None
+    if default_value == "None":
+        default_value = None
+    return env_value, default_value
+
+
+def _get_env_value(value: str, value_type: _T):
+    # Based on the start and end regex ops find the value the user set
+    env_str = END_REGEX_OP.split(CLIP_REGEX_OP.split(value)[1])[0]
+    # Attempt to split on a comma for a default value
+    split_len = len(env_str.split(','))
+    # Default found if the len is 2
+    if split_len == 2:
+        env_value, default_value = _handle_default(env_str)
+    # If the length is larger than two then the syntax is messed up
+    elif split_len > 2:
+        raise _SpockEnvResolverError(
+            f"Issue with environment variable syntax -- currently `{value}` has more than one `,` which means the "
+            f"optional default value cannot be resolved -- please use only one `,` separator within the syntax"
+        )
+    else:
+        env_value = env_str
+        default_value = "None"
+    # Attempt to get the env variable
+    if default_value == "None":
+        maybe_env = os.getenv(env_value)
+    else:
+        maybe_env = os.getenv(env_value, default_value)
+    if maybe_env is None and default_value == "None":
+        raise _SpockEnvResolverError(
+            f"Attempted to get `{env_value}` from environment variables but it is not set -- please set this "
+            f"variable or provide a default via the following syntax ${{spock.env:{env_value},DEFAULT}}"
+        )
+    else:
+        # Attempt to cast in a try to be able to catch the failed type casts with an exception
+        try:
+            typed_env = value_type(maybe_env) if maybe_env is not None else None
+        except Exception as e:
+            raise _SpockEnvResolverError(
+                f"Failed attempting to cast environment variable (name: {env_value}, value: `{maybe_env}`) "
+                f"into Spock specified type `{value_type.__name__}`"
+            )
+        return typed_env

--- a/spock/backend/resolvers.py
+++ b/spock/backend/resolvers.py
@@ -66,7 +66,11 @@ class BaseResolver(ABC):
     ):
         # Based on the start and end regex ops find the value the user set
         env_str = end_regex_op.split(clip_regex_op.split(value)[-1])[0]
-        if allow_annotation and len(clip_regex_op.split(value)) > 2 and clip_regex_op.split(value)[1] != "":
+        if (
+            allow_annotation
+            and len(clip_regex_op.split(value)) > 2
+            and clip_regex_op.split(value)[1] != ""
+        ):
             annotation = clip_regex_op.split(value)[1]
             if annotation not in self._annotation_set:
                 raise _SpockResolverError(

--- a/spock/backend/resolvers.py
+++ b/spock/backend/resolvers.py
@@ -4,87 +4,184 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """Resolver functions for Spock"""
-
-import re
 import os
-from typing import Any
+import re
+from abc import ABC, abstractmethod
+from typing import Any, ByteString, Optional, Tuple
 
-from spock.exceptions import _SpockEnvResolverError
+from spock.backend.utils import decrypt_value
+from spock.exceptions import _SpockResolverError
 from spock.utils import _T
 
 
-# ENV Resolver -- full regex is ^\${spock\.env:.*}$
-CLIP_ENV_PATTERN = r"^\${spock\.env:"
-CLIP_REGEX_OP = re.compile(CLIP_ENV_PATTERN)
-END_ENV_PATTERN = r"}$"
-END_REGEX_OP = re.compile(END_ENV_PATTERN)
-FULL_ENV_PATTERN = CLIP_ENV_PATTERN + r".*" + END_ENV_PATTERN
-FULL_REGEX_OP = re.compile(FULL_ENV_PATTERN)
+class BaseResolver(ABC):
+    def __init__(self):
+        self._annotation_set = {"crypto", "inject"}
 
+    @abstractmethod
+    def resolve(self, value: Any, value_type: _T) -> Tuple[Any, Optional[str]]:
+        pass
 
-def parse_env_variables(value: Any, value_type: _T) -> Any:
-    # Check if it matches the regex
-    # if so then split and replace with the value from the env -- have to check here if the env variable actually
-    # exists -- if it doesn't then we need to raise an exception -- allow for None?
+    @staticmethod
+    def _handle_default(value: str):
+        env_value, default_value = value.split(",")
+        default_value = default_value.strip()
+        # Swap string None to type None
+        if default_value == "None":
+            default_value = None
+        return env_value, default_value
 
-    # If it's a string we can check the regex
-    if isinstance(value, str):
-        # Check the regex
-        match_obj = FULL_REGEX_OP.fullmatch(value)
-        # if the object exists then we've matched a pattern and need to handle it
-        if match_obj is not None:
-            return _get_env_value(value, value_type)
-        # Regex doesn't match so just passthrough
+    @staticmethod
+    def _check_base_regex(
+        full_regex_op: re.Pattern,
+        value: Any,
+    ) -> bool:
+        # If it's a string we can check the regex
+        if isinstance(value, str):
+            # Check the regex and return non None status
+            return full_regex_op.fullmatch(value) is not None
+        # If it's not a string we can't resolve anything so just passthrough and let spock handle the value
         else:
-            return value
-    # If it's not a string we can't resolve anything so just passthrough and let spock handle the value
-    else:
-        return value
+            return False
 
-
-def _handle_default(value: str):
-    env_value, default_value = value.split(',')
-    default_value = default_value.strip()
-    # Swap string None to type None
-    if default_value == "None":
-        default_value = None
-    return env_value, default_value
-
-
-def _get_env_value(value: str, value_type: _T):
-    # Based on the start and end regex ops find the value the user set
-    env_str = END_REGEX_OP.split(CLIP_REGEX_OP.split(value)[1])[0]
-    # Attempt to split on a comma for a default value
-    split_len = len(env_str.split(','))
-    # Default found if the len is 2
-    if split_len == 2:
-        env_value, default_value = _handle_default(env_str)
-    # If the length is larger than two then the syntax is messed up
-    elif split_len > 2:
-        raise _SpockEnvResolverError(
-            f"Issue with environment variable syntax -- currently `{value}` has more than one `,` which means the "
-            f"optional default value cannot be resolved -- please use only one `,` separator within the syntax"
-        )
-    else:
-        env_value = env_str
-        default_value = "None"
-    # Attempt to get the env variable
-    if default_value == "None":
-        maybe_env = os.getenv(env_value)
-    else:
-        maybe_env = os.getenv(env_value, default_value)
-    if maybe_env is None and default_value == "None":
-        raise _SpockEnvResolverError(
-            f"Attempted to get `{env_value}` from environment variables but it is not set -- please set this "
-            f"variable or provide a default via the following syntax ${{spock.env:{env_value},DEFAULT}}"
-        )
-    else:
+    @staticmethod
+    def _attempt_cast(maybe_env: Optional[str], value_type: _T, env_value: str):
         # Attempt to cast in a try to be able to catch the failed type casts with an exception
         try:
             typed_env = value_type(maybe_env) if maybe_env is not None else None
         except Exception as e:
-            raise _SpockEnvResolverError(
+            raise _SpockResolverError(
                 f"Failed attempting to cast environment variable (name: {env_value}, value: `{maybe_env}`) "
                 f"into Spock specified type `{value_type.__name__}`"
             )
         return typed_env
+
+    def _apply_regex(
+        self,
+        end_regex_op: re.Pattern,
+        clip_regex_op: re.Pattern,
+        value: str,
+        allow_default: bool,
+        allow_annotation: bool,
+    ):
+        # Based on the start and end regex ops find the value the user set
+        env_str = end_regex_op.split(clip_regex_op.split(value)[-1])[0]
+        if allow_annotation and len(clip_regex_op.split(value)) > 2 and clip_regex_op.split(value)[1] != "":
+            annotation = clip_regex_op.split(value)[1]
+            if annotation not in self._annotation_set:
+                raise _SpockResolverError(
+                    f"Environment variable annotation must be within {self._annotation_set} -- got `{annotation}`"
+                )
+        elif not allow_annotation and len(clip_regex_op.split(value)) > 2:
+            raise _SpockResolverError(
+                f"Found annotation style format however `{value}` does not support annotations"
+            )
+        else:
+            annotation = None
+        # Attempt to split on a comma for a default value
+        split_len = len(env_str.split(","))
+        # Default found if the len is 2
+        if split_len == 2 and allow_default:
+            env_value, default_value = self._handle_default(env_str)
+        # If the length is larger than two then the syntax is messed up
+        elif split_len > 2 and allow_default:
+            raise _SpockResolverError(
+                f"Issue with environment variable syntax -- currently `{value}` has more than one `,` which means the "
+                f"optional default value cannot be resolved -- please use only one `,` separator within the syntax"
+            )
+        elif split_len > 1 and not allow_default:
+            raise _SpockResolverError(
+                f"Syntax does not support default values -- currently `{value}` contains the separator `,` which "
+                f"id used to indicate default values"
+            )
+        else:
+            env_value = env_str
+            default_value = "None"
+        return env_value, default_value, annotation
+
+
+class EnvResolver(BaseResolver):
+    # ENV Resolver -- full regex is ^\${spock\.env:.*}$
+    CLIP_ENV_PATTERN = r"^\${spock\.env\.?([a-z]*?):"
+    CLIP_REGEX_OP = re.compile(CLIP_ENV_PATTERN)
+    END_ENV_PATTERN = r"}$"
+    END_REGEX_OP = re.compile(END_ENV_PATTERN)
+    FULL_ENV_PATTERN = CLIP_ENV_PATTERN + r".*" + END_ENV_PATTERN
+    FULL_REGEX_OP = re.compile(FULL_ENV_PATTERN)
+
+    def __init__(self):
+        super(EnvResolver, self).__init__()
+
+    def resolve(self, value: Any, value_type: _T) -> Tuple[Any, Optional[str]]:
+        # Check the full regex for a match
+        regex_match = self._check_base_regex(self.FULL_REGEX_OP, value)
+        # if there is a regex match it needs to be handled by the underlying resolver ops
+        if regex_match:
+            # Apply the regex
+            env_value, default_value, annotation = self._apply_regex(
+                self.END_REGEX_OP,
+                self.CLIP_REGEX_OP,
+                value,
+                allow_default=True,
+                allow_annotation=True,
+            )
+            # Get the value from the env
+            maybe_env = self._get_from_env(default_value, env_value)
+            # Attempt to cast the value to its underlying type
+            typed_env = self._attempt_cast(maybe_env, value_type, env_value)
+        # Else just pass through
+        else:
+            typed_env = value
+            annotation = None
+        return typed_env, annotation
+
+    @staticmethod
+    def _get_from_env(default_value: Optional[str], env_value: str):
+        # Attempt to get the env variable
+        if default_value == "None":
+            maybe_env = os.getenv(env_value)
+        else:
+            maybe_env = os.getenv(env_value, default_value)
+        if maybe_env is None and default_value == "None":
+            raise _SpockResolverError(
+                f"Attempted to get `{env_value}` from environment variables but it is not set -- please set this "
+                f"variable or provide a default via the following syntax ${{spock.env:{env_value},DEFAULT}}"
+            )
+        return maybe_env
+
+
+class CryptoResolver(BaseResolver):
+    # ENV Resolver -- full regex is ^\${spock\.crypto:.*}$
+    CLIP_ENV_PATTERN = r"^\${spock\.crypto:"
+    CLIP_REGEX_OP = re.compile(CLIP_ENV_PATTERN)
+    END_ENV_PATTERN = r"}$"
+    END_REGEX_OP = re.compile(END_ENV_PATTERN)
+    FULL_ENV_PATTERN = CLIP_ENV_PATTERN + r".*" + END_ENV_PATTERN
+    FULL_REGEX_OP = re.compile(FULL_ENV_PATTERN)
+
+    def __init__(self, salt: str, key: ByteString):
+        super(CryptoResolver, self).__init__()
+        self._salt = salt
+        self._key = key
+
+    def resolve(self, value: Any, value_type: _T) -> Tuple[Any, Optional[str]]:
+        regex_match = self._check_base_regex(self.FULL_REGEX_OP, value)
+        if regex_match:
+            crypto_value, default_value, annotation = self._apply_regex(
+                self.END_REGEX_OP,
+                self.CLIP_REGEX_OP,
+                value,
+                allow_default=False,
+                allow_annotation=False,
+            )
+            decrypted_value = decrypt_value(crypto_value, self._key, self._salt)
+            typed_decrypted = self._attempt_cast(
+                decrypted_value, value_type, crypto_value
+            )
+            annotation = "crypto"
+        # Pass through
+        else:
+            typed_decrypted = value
+            annotation = None
+        # Crypto in --> crypto out annotation wise or else this exposes the value in plaintext
+        return typed_decrypted, annotation

--- a/spock/backend/saver.py
+++ b/spock/backend/saver.py
@@ -13,7 +13,7 @@ import attr
 from spock.backend.handler import BaseHandler
 from spock.backend.utils import _callable_2_str, _get_iter, _recurse_callables
 from spock.backend.wrappers import Spockspace
-from spock.utils import add_info, get_packages, _T
+from spock.utils import _T, add_info, get_packages
 
 
 class BaseSaver(BaseHandler):  # pylint: disable=too-few-public-methods

--- a/spock/backend/saver.py
+++ b/spock/backend/saver.py
@@ -84,10 +84,13 @@ class BaseSaver(BaseHandler):  # pylint: disable=too-few-public-methods
         out_dict = self._clean_up_values(payload)
         # Handle any env annotations that are present
         # Just stuff them into the dictionary
+        crypto_flag = False
         for k, v in payload:
             if hasattr(v, "__resolver__"):
                 for key, val in v.__resolver__.items():
                     out_dict[k][key] = val
+            if hasattr(v, "__crypto__"):
+                crypto_flag = True
         # Fix up the tuner values if present
         tuner_dict = (
             self._clean_tuner_values(tuner_payload)
@@ -108,6 +111,8 @@ class BaseSaver(BaseHandler):  # pylint: disable=too-few-public-methods
                 name=name,
                 create_path=create_save_path,
                 s3_config=self._s3_config,
+                salt=payload.__salt__ if crypto_flag else None,
+                key=payload.__key__ if crypto_flag else None,
             )
         except OSError as e:
             print(f"Unable to write to given path: {path / name}")

--- a/spock/backend/spaces.py
+++ b/spock/backend/spaces.py
@@ -55,6 +55,15 @@ class AttributeSpace:
         """
         self.config_space = config_space
         self.attribute = attribute
+        self._annotations = None
+
+    @property
+    def annotations(self):
+        return self._annotations
+
+    @annotations.setter
+    def annotations(self, x):
+        self._annotations = x
 
     @property
     def field(self):

--- a/spock/backend/spaces.py
+++ b/spock/backend/spaces.py
@@ -56,6 +56,7 @@ class AttributeSpace:
         self.config_space = config_space
         self.attribute = attribute
         self._annotations = None
+        self.crypto = False
 
     @property
     def annotations(self):

--- a/spock/backend/typed.py
+++ b/spock/backend/typed.py
@@ -389,7 +389,15 @@ def _type_katra(typed, default=None, optional=False):
         optional = True
         special_key = name
         typed = str
-    if default is not None:
+    if default is not None and optional:
+        # if a default is provided, that takes precedence
+        x = attr.ib(
+            validator=attr.validators.optional(attr.validators.instance_of(typed)),
+            default=default,
+            type=typed,
+            metadata={"optional": True, "base": name, "special_key": special_key},
+        )
+    elif default is not None:
         # if a default is provided, that takes precedence
         x = attr.ib(
             validator=attr.validators.instance_of(typed),

--- a/spock/backend/typed.py
+++ b/spock/backend/typed.py
@@ -410,7 +410,8 @@ def _type_katra(typed, default=None, optional=False):
     # Default booleans to false and optional due to the nature of a boolean
     if isinstance(typed, type) and name == "bool":
         optional = True
-        if default is not True:
+        # if it's a string -- it could be an env resolver -- pass it through
+        if (not isinstance(default, str)) and (default is not True):
             default = False
     # For the save path type we need to swap the type back to it's base class (str)
     elif isinstance(typed, type) and name == "SavePath":

--- a/spock/backend/typed.py
+++ b/spock/backend/typed.py
@@ -138,7 +138,19 @@ def _generic_alias_katra(typed, default=None, optional=False):
     """
     # base python class from which a GenericAlias is derived
     base_typed = typed.__origin__
-    if default is not None:
+    if default is not None and optional:
+        # if there's no default, but marked as optional, then set the default to None
+        x = attr.ib(
+            validator=attr.validators.optional(_recursive_generic_validator(typed)),
+            type=base_typed,
+            default=default,
+            metadata={
+                "optional": True,
+                "base": _extract_base_type(typed),
+                "type": typed,
+            },
+        )
+    elif default is not None:
         x = attr.ib(
             validator=_recursive_generic_validator(typed),
             default=default,
@@ -261,7 +273,16 @@ def _enum_base_katra(typed, base_type, allowed, default=None, optional=False):
         x: Attribute from attrs
 
     """
-    if default is not None:
+    if default is not None and optional:
+        x = attr.ib(
+            validator=attr.validators.optional(
+                [attr.validators.instance_of(base_type), attr.validators.in_(allowed)]
+            ),
+            default=_cast_enum_default(default),
+            type=typed,
+            metadata={"base": typed.__name__, "optional": True},
+        )
+    elif default is not None:
         x = attr.ib(
             validator=[
                 attr.validators.instance_of(base_type),
@@ -330,7 +351,14 @@ def _enum_class_katra(typed, allowed, default=None, optional=False):
         x: Attribute from attrs
 
     """
-    if default is not None:
+    if default is not None and optional:
+        x = attr.ib(
+            validator=attr.validators.optional([partial(_in_type, options=allowed)]),
+            default=_cast_enum_default(default),
+            type=typed,
+            metadata={"base": typed.__name__, "optional": True},
+        )
+    elif default is not None:
         x = attr.ib(
             validator=[partial(_in_type, options=allowed)],
             default=_cast_enum_default(default),
@@ -470,7 +498,14 @@ def _callable_katra(typed, default=None, optional=False):
         x: Attribute from attrs
 
     """
-    if default is not None:
+    if default is not None and optional:
+        x = attr.ib(
+            validator=attr.validators.optional(attr.validators.is_callable()),
+            default=default,
+            type=typed,
+            metadata={"optional": True, "base": _get_name_py_version(typed)},
+        )
+    elif default is not None:
         # if a default is provided, that takes precedence
         x = attr.ib(
             validator=attr.validators.is_callable(),

--- a/spock/backend/utils.py
+++ b/spock/backend/utils.py
@@ -8,8 +8,27 @@
 import importlib
 from typing import Any, Callable, Dict, List, Tuple, Type, Union
 
+from cryptography.fernet import Fernet
+
 from spock.exceptions import _SpockValueError
 from spock.utils import _C, _T, _SpockVariadicGenericAlias
+
+
+def encrypt_value(value, key, salt):
+    # Make the class to encrypt
+    encrypt = Fernet(key=key)
+    # Encrypt the plaintext value
+    salted_password = value + salt
+    # encode to utf-8 -> encrypt -> decode from utf-8
+    return encrypt.encrypt(str.encode(salted_password)).decode()
+
+
+def decrypt_value(value, key, salt):
+    # Make the class to encrypt
+    decrypt = Fernet(key=key)
+    # Decrypt back to plaintext value
+    salted_password = decrypt.decrypt(str.encode(value)).decode()
+    return salted_password[: -len(salt)]
 
 
 def _str_2_callable(val: str, **kwargs):

--- a/spock/backend/wrappers.py
+++ b/spock/backend/wrappers.py
@@ -23,7 +23,9 @@ class Spockspace(argparse.Namespace):
     @property
     def __repr_dict__(self):
         """Handles making a clean dict to hind the salt and key on print"""
-        return {k: v for k, v in self.__dict__.items() if k not in {"__key__", "__salt__"}}
+        return {
+            k: v for k, v in self.__dict__.items() if k not in {"__key__", "__salt__"}
+        }
 
     def __repr__(self):
         """Overloaded repr to pretty print the spock object"""

--- a/spock/backend/wrappers.py
+++ b/spock/backend/wrappers.py
@@ -24,3 +24,7 @@ class Spockspace(argparse.Namespace):
         # Remove aliases in YAML print
         yaml.Dumper.ignore_aliases = lambda *args: True
         return yaml.dump(self.__dict__, default_flow_style=False)
+
+    def __iter__(self):
+        for k, v in self.__dict__.items():
+            yield k, v

--- a/spock/backend/wrappers.py
+++ b/spock/backend/wrappers.py
@@ -20,10 +20,14 @@ class Spockspace(argparse.Namespace):
     def __init__(self, **kwargs):
         super(Spockspace, self).__init__(**kwargs)
 
+    @property
+    def __repr_dict__(self):
+        return {k: v for k, v in self.__dict__.items() if k not in {"__key__", "__salt__"}}
+
     def __repr__(self):
         # Remove aliases in YAML print
         yaml.Dumper.ignore_aliases = lambda *args: True
-        return yaml.dump(self.__dict__, default_flow_style=False)
+        return yaml.dump(self.__repr_dict__, default_flow_style=False)
 
     def __iter__(self):
         for k, v in self.__dict__.items():

--- a/spock/backend/wrappers.py
+++ b/spock/backend/wrappers.py
@@ -22,13 +22,16 @@ class Spockspace(argparse.Namespace):
 
     @property
     def __repr_dict__(self):
+        """Handles making a clean dict to hind the salt and key on print"""
         return {k: v for k, v in self.__dict__.items() if k not in {"__key__", "__salt__"}}
 
     def __repr__(self):
+        """Overloaded repr to pretty print the spock object"""
         # Remove aliases in YAML print
         yaml.Dumper.ignore_aliases = lambda *args: True
         return yaml.dump(self.__repr_dict__, default_flow_style=False)
 
     def __iter__(self):
+        """Iter for the underlying dictionary"""
         for k, v in self.__dict__.items():
             yield k, v

--- a/spock/builder.py
+++ b/spock/builder.py
@@ -280,7 +280,9 @@ class ConfigArgBuilder:
                 from spock.addons.tune.builder import TunerBuilder
                 from spock.addons.tune.payload import TunerPayload
 
-                tuner_builder = TunerBuilder(*tune_args, **kwargs, lazy=self._lazy, salt=self.salt, key=self.key)
+                tuner_builder = TunerBuilder(
+                    *tune_args, **kwargs, lazy=self._lazy, salt=self.salt, key=self.key
+                )
                 tuner_payload = TunerPayload(s3_config=s3_config)
                 return tuner_builder, tuner_payload
             except ImportError:

--- a/spock/builder.py
+++ b/spock/builder.py
@@ -74,9 +74,8 @@ class ConfigArgBuilder:
         lazy: bool = False,
         no_cmd_line: bool = False,
         s3_config: Optional[_T] = None,
-        key: Optional[Union[str, ByteString]],
-        salt: Optional[str],
-        crypto: Optional[Union[str, Tuple[str, ByteString]]] = None,
+        key: Optional[Union[str, ByteString]] = None,
+        salt: Optional[str] = None,
         **kwargs,
     ):
         """Init call for ConfigArgBuilder
@@ -806,7 +805,7 @@ class ConfigArgBuilder:
         salt: Optional[str],
         s3_config: Optional[_T] = None,
         salt_len: int = 16,
-    ):
+    ) -> Tuple[str, ByteString]:
         """Handles setting up the underlying cryptography needs
 
         Args:
@@ -831,7 +830,7 @@ class ConfigArgBuilder:
         env_resolver: EnvResolver,
         salt_len: int,
         s3_config: Optional[_T] = None,
-    ):
+    ) -> str:
         """
 
         Args:
@@ -858,7 +857,7 @@ class ConfigArgBuilder:
         key: Optional[Union[str, ByteString]],
         env_resolver: EnvResolver,
         s3_config: Optional[_T] = None,
-    ):
+    ) -> ByteString:
         """
 
         Args:
@@ -885,7 +884,7 @@ class ConfigArgBuilder:
         return key
 
     @staticmethod
-    def _handle_yaml_read(value: str, access: str, s3_config: Optional[_T] = None, encode: bool = False):
+    def _handle_yaml_read(value: str, access: str, s3_config: Optional[_T] = None, encode: bool = False) -> Union[str, ByteString]:
         """Reads in a salt/key yaml
 
         Args:

--- a/spock/builder.py
+++ b/spock/builder.py
@@ -6,6 +6,7 @@
 """Handles the building/saving of the configurations from the Spock config classes"""
 
 import argparse
+import os.path
 import sys
 from collections import Counter
 from copy import deepcopy
@@ -73,6 +74,8 @@ class ConfigArgBuilder:
         lazy: bool = False,
         no_cmd_line: bool = False,
         s3_config: Optional[_T] = None,
+        key: Optional[Union[str, ByteString]],
+        salt: Optional[str],
         crypto: Optional[Union[str, Tuple[str, ByteString]]] = None,
         **kwargs,
     ):
@@ -87,7 +90,9 @@ class ConfigArgBuilder:
                 @spock decorated classes to *args
             no_cmd_line: turn off cmd line args
             s3_config: s3Config object for S3 support
-            crypto: either a path to a prior spock saved crypto.yaml file or a tuple of a cryptographic salt and key
+            salt: either a path to a prior spock saved salt.yaml file or a string of the salt (can be an env reference)
+            key: either a path to a prior spock saved key.yaml file, a ByteString of the key, or a str of the key
+                (can be an env reference)
             **kwargs: keyword args
 
         """
@@ -97,7 +102,7 @@ class ConfigArgBuilder:
         self._lazy = lazy
         self._no_cmd_line = no_cmd_line
         self._desc = desc
-        self._salt, self._key = self._maybe_crypto(crypto, s3_config)
+        self._salt, self._key = self._maybe_crypto(key, salt, s3_config)
         # Build the payload and saver objects
         self._payload_obj = AttrPayload(s3_config=s3_config)
         self._saver_obj = AttrSaver(s3_config=s3_config)
@@ -128,6 +133,9 @@ class ConfigArgBuilder:
             # Build the Spockspace from the payload and the classes
             # Fixed configs
             self._arg_namespace = self._builder_obj.generate(self._dict_args)
+            # Attach the key and salt to the Spockspace
+            self._arg_namespace.__salt__ = self.salt
+            self._arg_namespace.__key__ = self.key
             # Get the payload from the config files -- hyper-parameters -- only if the obj is not None
             if self._tune_obj is not None:
                 self._tune_args = self._get_payload(
@@ -792,16 +800,19 @@ class ConfigArgBuilder:
                 )
         return new_arg_namespace
 
-    @staticmethod
     def _maybe_crypto(
-        crypto: Optional[Union[str, Tuple[str, ByteString]]],
+        self,
+        key: Optional[Union[str, ByteString]],
+        salt: Optional[str],
         s3_config: Optional[_T] = None,
         salt_len: int = 16,
     ):
         """Handles setting up the underlying cryptography needs
 
         Args:
-            crypto: either a path to a prior spock saved crypto.yaml file or a tuple of a cryptographic salt and key
+            salt: either a path to a prior spock saved salt.yaml file or a string of the salt (can be an env reference)
+            key: either a path to a prior spock saved key.yaml file, a ByteString of the key, or a str of the key
+                (can be an env reference)
             s3_config: s3Config object for S3 support
             salt_len: length of the salt to create
 
@@ -809,25 +820,88 @@ class ConfigArgBuilder:
             tuple containing a salt and a key that spock can use to hide parameters
 
         """
-        if isinstance(crypto, str):
-            # Read from the yaml and then split
-            payload = YAMLHandler().load(Path(crypto), s3_config)
-            salt = payload["salt"]
-            key = payload["key"]
-        elif isinstance(crypto, (tuple, Tuple)):
-            # order is salt, key
-            salt, key = crypto
-        elif crypto is None:
-            salt = make_salt(salt_len)
-            key = Fernet.generate_key()
-        else:
-            raise _SpockCryptoError(
-                f"The crypto argument expects a path to a valid prior spock saved crypto.yaml file, a tuple of a "
-                f"cryptographic salt and key (as raw strings or using env resolver syntax), or None -- got "
-                f"type {type(crypto)} and value `{crypto}`"
-            )
-        # Parse if defined by env vars
         env_resolver = EnvResolver()
-        salt, _ = env_resolver.resolve(salt, str)
-        key, _ = env_resolver.resolve(key, str)
+        salt = self._get_salt(salt, env_resolver, salt_len, s3_config)
+        key = self._get_key(key, env_resolver, s3_config)
         return salt, key
+
+    def _get_salt(
+        self,
+        salt: Optional[str],
+        env_resolver: EnvResolver,
+        salt_len: int,
+        s3_config: Optional[_T] = None,
+    ):
+        """
+
+        Args:
+            salt: either a path to a prior spock saved salt.yaml file or a string of the salt (can be an env reference)
+            env_resolver: EnvResolver class to handle env variable resolution if needed
+            salt_len: length of the salt to create
+            s3_config: s3Config object for S3 support
+
+        Returns:
+            salt as a string
+
+        """
+        # Byte string is assumed to be a direct key
+        if salt is None:
+            salt = make_salt(salt_len)
+        elif os.path.splitext(salt)[1] in {".yaml", ".YAML", ".yml", ".YML"}:
+            salt = self._handle_yaml_read(salt, access="salt", s3_config=s3_config)
+        else:
+            salt, _ = env_resolver.resolve(salt, str)
+        return salt
+
+    def _get_key(
+        self,
+        key: Optional[Union[str, ByteString]],
+        env_resolver: EnvResolver,
+        s3_config: Optional[_T] = None,
+    ):
+        """
+
+        Args:
+            key: either a path to a prior spock saved key.yaml file, a ByteString of the key, or a str of the key
+                (can be an env reference)
+            env_resolver: EnvResolver class to handle env variable resolution if needed
+            s3_config: s3Config object for S3 support
+
+        Returns:
+            key as ByteString
+
+        """
+        if key is None:
+            key = Fernet.generate_key()
+        # Byte string is assumed to be a direct key
+        elif os.path.splitext(key)[1] in {".yaml", ".YAML", ".yml", ".YML"}:
+            key = self._handle_yaml_read(key, access="key", s3_config=s3_config, encode=True)
+        else:
+            # Byte string is assumed to be a direct key
+            # So only handle the str here
+            if isinstance(key, str):
+                key, _ = env_resolver.resolve(key, str)
+                key = str.encode(key)
+        return key
+
+    @staticmethod
+    def _handle_yaml_read(value: str, access: str, s3_config: Optional[_T] = None, encode: bool = False):
+        """Reads in a salt/key yaml
+
+        Args:
+            value: path to the key/salt yaml
+            access: which variable name to use from the yaml
+            s3_config: s3Config object for S3 support
+
+        Returns:
+
+        """
+        # Read from the yaml and then split
+        try:
+            payload = YAMLHandler().load(Path(value), s3_config)
+            read_value = payload[access]
+            if encode:
+                read_value = str.encode(read_value)
+            return read_value
+        except Exception as e:
+            _SpockCryptoError(f"Attempted to read from path `{value}` but failed")

--- a/spock/builder.py
+++ b/spock/builder.py
@@ -874,7 +874,9 @@ class ConfigArgBuilder:
             key = Fernet.generate_key()
         # Byte string is assumed to be a direct key
         elif os.path.splitext(key)[1] in {".yaml", ".YAML", ".yml", ".YML"}:
-            key = self._handle_yaml_read(key, access="key", s3_config=s3_config, encode=True)
+            key = self._handle_yaml_read(
+                key, access="key", s3_config=s3_config, encode=True
+            )
         else:
             # Byte string is assumed to be a direct key
             # So only handle the str here
@@ -884,7 +886,9 @@ class ConfigArgBuilder:
         return key
 
     @staticmethod
-    def _handle_yaml_read(value: str, access: str, s3_config: Optional[_T] = None, encode: bool = False) -> Union[str, ByteString]:
+    def _handle_yaml_read(
+        value: str, access: str, s3_config: Optional[_T] = None, encode: bool = False
+    ) -> Union[str, ByteString]:
         """Reads in a salt/key yaml
 
         Args:

--- a/spock/builder.py
+++ b/spock/builder.py
@@ -280,7 +280,7 @@ class ConfigArgBuilder:
                 from spock.addons.tune.builder import TunerBuilder
                 from spock.addons.tune.payload import TunerPayload
 
-                tuner_builder = TunerBuilder(*tune_args, **kwargs, lazy=self._lazy)
+                tuner_builder = TunerBuilder(*tune_args, **kwargs, lazy=self._lazy, salt=self.salt, key=self.key)
                 tuner_payload = TunerPayload(s3_config=s3_config)
                 return tuner_builder, tuner_payload
             except ImportError:

--- a/spock/exceptions.py
+++ b/spock/exceptions.py
@@ -40,7 +40,13 @@ class _SpockValueError(Exception):
     pass
 
 
-class _SpockEnvResolverError(Exception):
+class _SpockResolverError(Exception):
     """Custom exception for environment resolver"""
+
+    pass
+
+
+class _SpockCryptoError(Exception):
+    """Custom exception for dealing with the crypto side of things"""
 
     pass

--- a/spock/exceptions.py
+++ b/spock/exceptions.py
@@ -38,3 +38,9 @@ class _SpockValueError(Exception):
     """Custom exception for throwing value errors"""
 
     pass
+
+
+class _SpockEnvResolverError(Exception):
+    """Custom exception for environment resolver"""
+
+    pass

--- a/spock/handlers.py
+++ b/spock/handlers.py
@@ -202,7 +202,9 @@ class Handler(ABC):
         raise NotImplementedError
 
     @staticmethod
-    def _handle_possible_s3_load_path(path: Path, s3_config: Optional[_T] = None) -> Union[str, Path]:
+    def _handle_possible_s3_load_path(
+        path: Path, s3_config: Optional[_T] = None
+    ) -> Union[str, Path]:
         """Handles the possibility of having to handle loading from a S3 path
 
         Checks to see if it detects a S3 uri and if so triggers imports of s3 functionality and handles the file

--- a/spock/handlers.py
+++ b/spock/handlers.py
@@ -334,7 +334,6 @@ class YAMLHandler(Handler):
 
         """
         file_contents = open(path, "r").read()
-        file_contents = re.sub(r"--([a-zA-Z0-9_]*)", r"\g<1>: True", file_contents)
         base_payload = yaml.safe_load(file_contents)
         return base_payload
 

--- a/spock/handlers.py
+++ b/spock/handlers.py
@@ -72,6 +72,7 @@ class Handler(ABC):
         self,
         out_dict: Dict,
         info_dict: Optional[Dict],
+        library_dict: Optional[Dict],
         path: Path,
         name: str,
         create_path: bool = False,
@@ -85,6 +86,7 @@ class Handler(ABC):
         Args:
             out_dict: payload to write
             info_dict: info payload to write
+            library_dict: package info to write
             path: path to write out
             name: spock generated file name
             create_path: boolean to create the path if non-existent (for non S3)
@@ -95,7 +97,12 @@ class Handler(ABC):
         write_path, is_s3 = self._handle_possible_s3_save_path(
             path=path, name=name, create_path=create_path, s3_config=s3_config
         )
-        write_path = self._save(out_dict=out_dict, info_dict=info_dict, path=write_path)
+        write_path = self._save(
+            out_dict=out_dict,
+            info_dict=info_dict,
+            library_dict=library_dict,
+            path=write_path,
+        )
         # After write check if it needs to be pushed to S3
         if is_s3:
             try:
@@ -111,12 +118,19 @@ class Handler(ABC):
                 print("Error importing spock s3 utils after detecting s3:// save path")
 
     @abstractmethod
-    def _save(self, out_dict: Dict, info_dict: Optional[Dict], path: str) -> str:
+    def _save(
+        self,
+        out_dict: Dict,
+        info_dict: Optional[Dict],
+        library_dict: Optional[Dict],
+        path: str,
+    ) -> str:
         """Write function for file type
 
         Args:
             out_dict: payload to write
             info_dict: info payload to write
+            library_dict: package info to write
             path: path to write out
 
         Returns:
@@ -182,19 +196,35 @@ class Handler(ABC):
         return write_path, is_s3
 
     @staticmethod
-    def write_extra_info(path, info_dict):
+    def write_extra_info(
+        path: str,
+        info_dict: Dict,
+        version: bool = True,
+        write_mode: str = "w+",
+        newlines: Optional[int] = None,
+        header: Optional[str] = None,
+    ):
         """Writes extra info to commented newlines
 
         Args:
             path: path to write out
             info_dict: info payload to write
+            version: write the spock version string first
+            write_mode: write mode for the file
+            newlines: number of new lines to add to start
 
         Returns:
         """
         # Write the commented info as new lines
-        with open(path, "w+") as fid:
+        with open(path, write_mode) as fid:
+            if newlines is not None:
+                for _ in range(newlines):
+                    fid.write("\n")
+            if header is not None:
+                fid.write(header)
             # Write a spock header
-            fid.write(f"# Spock Version: {__version__}\n")
+            if version:
+                fid.write(f"# Spock Version: {__version__}\n")
             # Write info dict if not None
             if info_dict is not None:
                 for k, v in info_dict.items():
@@ -242,12 +272,19 @@ class YAMLHandler(Handler):
         base_payload = yaml.safe_load(file_contents)
         return base_payload
 
-    def _save(self, out_dict: Dict, info_dict: Optional[Dict], path: str) -> str:
+    def _save(
+        self,
+        out_dict: Dict,
+        info_dict: Optional[Dict],
+        library_dict: Optional[Dict],
+        path: str,
+    ) -> str:
         """Write function for YAML type
 
         Args:
             out_dict: payload to write
             info_dict: info payload to write
+            library_dict: package info to write
             path: path to write out
 
         Returns:
@@ -258,6 +295,15 @@ class YAMLHandler(Handler):
         yaml.Dumper.ignore_aliases = lambda *args: True
         with open(path, "a") as yaml_fid:
             yaml.safe_dump(out_dict, yaml_fid, default_flow_style=False)
+        # Write the library info at the bottom
+        self.write_extra_info(
+            path=path,
+            info_dict=library_dict,
+            version=False,
+            write_mode="a",
+            newlines=2,
+            header="################\n# Package Info #\n################\n",
+        )
         return path
 
 
@@ -281,12 +327,19 @@ class TOMLHandler(Handler):
         base_payload = pytomlpp.load(path)
         return base_payload
 
-    def _save(self, out_dict: Dict, info_dict: Optional[Dict], path: str) -> str:
+    def _save(
+        self,
+        out_dict: Dict,
+        info_dict: Optional[Dict],
+        library_dict: Optional[Dict],
+        path: str,
+    ) -> str:
         """Write function for TOML type
 
         Args:
             out_dict: payload to write
             info_dict: info payload to write
+            library_dict: package info to write
             path: path to write out
 
         Returns:
@@ -295,6 +348,10 @@ class TOMLHandler(Handler):
         self.write_extra_info(path=path, info_dict=info_dict)
         with open(path, "a") as toml_fid:
             pytomlpp.dump(out_dict, toml_fid)
+        # Write the library info at the bottom
+        self.write_extra_info(
+            path=path, info_dict=library_dict, version=False, write_mode="a", newlines=2
+        )
         return path
 
 
@@ -319,17 +376,24 @@ class JSONHandler(Handler):
             base_payload = json.load(json_fid)
         return base_payload
 
-    def _save(self, out_dict: Dict, info_dict: Optional[Dict], path: str) -> str:
+    def _save(
+        self,
+        out_dict: Dict,
+        info_dict: Optional[Dict],
+        library_dict: Optional[Dict],
+        path: str,
+    ) -> str:
         """Write function for JSON type
 
         Args:
             out_dict: payload to write
             info_dict: info payload to write
+            library_dict: package info to write
             path: path to write out
 
         Returns:
         """
-        if info_dict is not None:
+        if (info_dict is not None) or (library_dict is not None):
             warn(
                 "JSON does not support comments and thus cannot save extra info to file... removing extra info"
             )

--- a/spock/handlers.py
+++ b/spock/handlers.py
@@ -29,7 +29,7 @@ class Handler(ABC):
 
     """
 
-    def load(self, path: Path, s3_config=None) -> Dict:
+    def load(self, path: Path, s3_config: Optional[_T] = None) -> Dict:
         """Load function for file type
 
         This handles s3 path conversion for all handler types pre load call
@@ -202,7 +202,7 @@ class Handler(ABC):
         raise NotImplementedError
 
     @staticmethod
-    def _handle_possible_s3_load_path(path: Path, s3_config=None) -> Union[str, Path]:
+    def _handle_possible_s3_load_path(path: Path, s3_config: Optional[_T] = None) -> Union[str, Path]:
         """Handles the possibility of having to handle loading from a S3 path
 
         Checks to see if it detects a S3 uri and if so triggers imports of s3 functionality and handles the file
@@ -229,7 +229,7 @@ class Handler(ABC):
 
     @staticmethod
     def _handle_possible_s3_save_path(
-        path: Path, name: str, create_path: bool, s3_config=None
+        path: Path, name: str, create_path: bool, s3_config: Optional[_T] = None
     ) -> Tuple[str, bool]:
         """Handles the possibility of having to save to a S3 path
 

--- a/spock/utils.py
+++ b/spock/utils.py
@@ -29,11 +29,26 @@ minor = sys.version_info.minor
 
 
 def make_salt(salt_len: int = 16):
+    """Make a salt of specific length
+
+    Args:
+        salt_len: length of the constructed salt
+
+    Returns:
+        salt string
+
+    """
     alphabet = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
-    return "".join(random.choice(alphabet) for i in range(salt_len))
+    return "".join(random.choice(alphabet) for _ in range(salt_len))
 
 
 def _get_alias_type():
+    """Gets the correct type of GenericAlias for versions less than 3.6
+
+    Returns:
+        _GenericAlias type
+
+    """
     if minor < 7:
         from typing import GenericMeta as _GenericAlias
     else:
@@ -43,6 +58,12 @@ def _get_alias_type():
 
 
 def _get_callable_type():
+    """Gets the correct underlying type reference for callable objects depending on the python version
+
+    Returns:
+        _VariadicGenericAlias type
+
+    """
     if minor == 6:
         from typing import CallableMeta as _VariadicGenericAlias
     elif (minor > 6) and (minor < 9):

--- a/spock/utils.py
+++ b/spock/utils.py
@@ -7,6 +7,7 @@
 
 import ast
 import os
+import random
 import socket
 import subprocess
 import sys
@@ -20,10 +21,16 @@ from warnings import warn
 
 import attr
 import git
+import pkg_resources
 
 from spock.exceptions import _SpockValueError
 
 minor = sys.version_info.minor
+
+
+def make_salt(salt_len: int = 16):
+    alphabet = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+    return "".join(random.choice(alphabet) for i in range(salt_len))
 
 
 def _get_alias_type():
@@ -478,6 +485,22 @@ def _handle_generic_type_args(val: str) -> Any:
 
     """
     return ast.literal_eval(val)
+
+
+def get_packages() -> Dict:
+    """Gets all currently installed packages and assembles a dictionary of name: version
+
+    Notes:
+        https://stackoverflow.com/a/50013400
+
+    Returns:
+        dictionary of all currently available packages
+
+    """
+    named_list = sorted([str(i.key) for i in pkg_resources.working_set])
+    return {
+        f"# {i}": str(pkg_resources.working_set.by_key[i].version) for i in named_list
+    }
 
 
 def add_info() -> Dict:

--- a/tests/base/test_post_hooks.py
+++ b/tests/base/test_post_hooks.py
@@ -182,8 +182,6 @@ class TestPostHooks:
                 )
                 config.generate()
 
-
-
     def test_eq_len_two_len_fail(self, monkeypatch, tmp_path):
         """Test serialization/de-serialization"""
         with monkeypatch.context() as m:

--- a/tests/base/test_resolvers.py
+++ b/tests/base/test_resolvers.py
@@ -240,21 +240,21 @@ class TestResolvers:
             curr_int_time = int(f"{now.year}{now.month}{now.day}{now.hour}{now.second}")
             config_values = config.save(
                 file_extension=".yaml",
-                file_name=f"pytest.{curr_int_time}",
+                file_name=f"pytest.crypto.{curr_int_time}",
                 user_specified_path=tmp_path
             ).generate()
             yaml_regex = re.compile(
-                fr"pytest.{curr_int_time}."
+                fr"pytest.crypto.{curr_int_time}."
                 fr"[a-fA-F0-9]{{8}}-[a-fA-F0-9]{{4}}-[a-fA-F0-9]{{4}}-"
                 fr"[a-fA-F0-9]{{4}}-[a-fA-F0-9]{{12}}.spock.cfg.yaml"
             )
             yaml_key_regex = re.compile(
-                fr"pytest.{curr_int_time}."
+                fr"pytest.crypto.{curr_int_time}."
                 fr"[a-fA-F0-9]{{8}}-[a-fA-F0-9]{{4}}-[a-fA-F0-9]{{4}}-"
                 fr"[a-fA-F0-9]{{4}}-[a-fA-F0-9]{{12}}.spock.cfg.key.yaml"
             )
             yaml_salt_regex = re.compile(
-                fr"pytest.{curr_int_time}."
+                fr"pytest.crypto.{curr_int_time}."
                 fr"[a-fA-F0-9]{{8}}-[a-fA-F0-9]{{4}}-[a-fA-F0-9]{{4}}-"
                 fr"[a-fA-F0-9]{{4}}-[a-fA-F0-9]{{12}}.spock.cfg.salt.yaml"
             )

--- a/tests/base/test_resolvers.py
+++ b/tests/base/test_resolvers.py
@@ -1,0 +1,290 @@
+# -*- coding: utf-8 -*-
+import sys
+import os
+
+import attr
+import pytest
+
+from spock import spock
+from spock import SpockBuilder
+from spock.exceptions import _SpockResolverError
+from typing import Optional
+
+
+@spock
+class EnvClass:
+    # Basic types no defaults
+    env_int: int = "${spock.env:INT}"
+    env_float: float = "${spock.env:FLOAT}"
+    env_bool: bool = "${spock.env:BOOL}"
+    env_str: str = "${spock.env:STRING}"
+    # Basic types w/ defaults
+    env_int_def: int = "${spock.env:INT_DEF, 3}"
+    env_float_def: float = "${spock.env:FLOAT_DEF, 3.0}"
+    env_bool_def: bool = "${spock.env:BOOL_DEF, True}"
+    env_str_def: str = "${spock.env:STRING_DEF, hello}"
+    # Basic types allowing None as default
+    env_int_def_opt: Optional[int] = "${spock.env:INT_DEF, None}"
+    env_float_def_opt: Optional[float] = "${spock.env:FLOAT_DEF, None}"
+    env_bool_def_opt: Optional[bool] = "${spock.env:BOOL_DEF, False}"
+    env_str_def_opt: Optional[str] = "${spock.env:STRING_DEF, None}"
+    # Basic types w/ defaults -- inject
+    env_int_def_inject: int = "${spock.env.inject:INT_DEF, 30}"
+    env_float_def_inject: float = "${spock.env.inject:FLOAT_DEF, 30.0}"
+    env_bool_def_inject: bool = "${spock.env.inject:BOOL_DEF, False}"
+    env_str_def_inject: str = "${spock.env.inject:STRING_DEF, hola}"
+    # Basic types w/ defaults -- to crypto
+    env_int_def_crypto: int = "${spock.env.crypto:INT_DEF, 300}"
+    env_float_def_crypto: float = "${spock.env.crypto:FLOAT_DEF, 300.0}"
+    env_bool_def_crypto: bool = "${spock.env.crypto:BOOL_DEF, True}"
+    env_str_def_crypto: str = "${spock.env.crypto:STRING_DEF, yikes}"
+
+
+@spock
+class FromCrypto:
+    # Basic types from crypto
+    env_int_def_from_crypto: int = "${spock.crypto:gAAAAABigpYHrKffEQ203V6L5YEikgAfuzOU6i0xigLinKlXeR7seWHji4aHyoQ-H9IGaXcCns65AZq-cSyXcUFtQ_9w43RUraUM-tqDdCXeiDygeA_BEC0=}"
+    env_float_def_from_crypto: float = "${spock.crypto:gAAAAABigpYHuJndgXM8wQ17uDblBfgm256VzXNjCiblpPfL08LndRWSG4E8v7rSPB7AmfoUwmvTW91b1qn1O1UL2aTNdNz-pmkmf6ZrOpxNnSgOF7TSpE8=}"
+    env_bool_def_from_crypto: bool = "${spock.crypto:gAAAAABigpYHfzExxlvyFcIjzOMn25Gj-2luN0tGQ1dpDb8lInCY3C5PNTlaV4xLxekQ6x2SJli37dpaRNB4vXBqE1MLU5V9Rth9dlu6olmEuomIzx8V_Nw=}"
+    env_str_def_from_crypto: str = "${spock.crypto:gAAAAABigpYH8mqVr8LCATnJBHyTAhnoO6nDXAjzyVlxiXSPSqlmYMp9h4i2S552DC_xQHgUiN11dbyD2psroKUxF_uPDRzhPfvG9mkZvbTEpMpb5JPqJxs=}"
+
+
+@spock
+class CastRaise:
+    cast_miss: int = "${spock.env:CAST_MISS}"
+
+
+@spock
+class AnnotationNotInSetRaise:
+    annotation_miss: int = "${spock.env.foobar:INT}"
+
+
+@spock
+class AnnotationNotAllowedRaise:
+    annotation_miss: int = "${spock.crypto.foobar:INT}"
+
+
+@spock
+class MultipleDefaults:
+    multi_def: int = "${spock.env:INT,one,two}"
+
+
+@spock
+class NoDefAllowed:
+    no_def: int = "${spock.crypto:INT,one}"
+
+
+@spock
+class NoEnv:
+    no_env: int = "${spock.env:PEEKABOO}"
+
+
+class TestResolverExceptions:
+    def test_no_env(self, monkeypatch, tmp_path):
+        """Test serialization/de-serialization"""
+        with monkeypatch.context() as m:
+            m.setattr(
+                sys,
+                "argv",
+                [""],
+            )
+            with pytest.raises(_SpockResolverError):
+                config = SpockBuilder(
+                    NoEnv,
+                    desc="Test Builder",
+                )
+                config.generate()
+
+    def test_no_def_allowed(self, monkeypatch, tmp_path):
+        """Test serialization/de-serialization"""
+        with monkeypatch.context() as m:
+            m.setattr(
+                sys,
+                "argv",
+                [""],
+            )
+            with pytest.raises(_SpockResolverError):
+                config = SpockBuilder(
+                    NoDefAllowed,
+                    desc="Test Builder",
+                )
+                config.generate()
+
+    def test_multiple_defaults(self, monkeypatch, tmp_path):
+        """Test serialization/de-serialization"""
+        with monkeypatch.context() as m:
+            m.setattr(
+                sys,
+                "argv",
+                [""],
+            )
+            with pytest.raises(_SpockResolverError):
+                config = SpockBuilder(
+                    MultipleDefaults,
+                    desc="Test Builder",
+                )
+                config.generate()
+
+
+    def test_cast_fail(self, monkeypatch, tmp_path):
+        """Test serialization/de-serialization"""
+        with monkeypatch.context() as m:
+            m.setattr(
+                sys,
+                "argv",
+                [""],
+            )
+            os.environ['CAST_MISS'] = "foo"
+            with pytest.raises(_SpockResolverError):
+                config = SpockBuilder(
+                    CastRaise,
+                    desc="Test Builder",
+                )
+                config.generate()
+
+    def test_annotation_not_in_set(self, monkeypatch, tmp_path):
+        """Test serialization/de-serialization"""
+        with monkeypatch.context() as m:
+            m.setattr(
+                sys,
+                "argv",
+                [""],
+            )
+            with pytest.raises(_SpockResolverError):
+                config = SpockBuilder(
+                    AnnotationNotInSetRaise,
+                    desc="Test Builder",
+                )
+                config.generate()
+
+    def test_annotation_not_allowed(self, monkeypatch, tmp_path):
+        """Test serialization/de-serialization"""
+        with monkeypatch.context() as m:
+            m.setattr(
+                sys,
+                "argv",
+                [""],
+            )
+            with pytest.raises(_SpockResolverError):
+                config = SpockBuilder(
+                    AnnotationNotAllowedRaise,
+                    desc="Test Builder",
+                )
+                config.generate()
+
+
+class TestResolvers:
+    """Testing resolvers functionality"""
+    @staticmethod
+    @pytest.fixture
+    def arg_builder_no_conf(monkeypatch):
+        with monkeypatch.context() as m:
+            m.setattr(sys, "argv", [""])
+            os.environ['INT'] = "1"
+            os.environ['FLOAT'] = "1.0"
+            os.environ["BOOL"] = "true"
+            os.environ["STRING"] = "ciao"
+            config = SpockBuilder(EnvClass)
+            return config.generate()
+
+    @staticmethod
+    @pytest.fixture
+    def arg_builder_conf(monkeypatch):
+        with monkeypatch.context() as m:
+            m.setattr(sys, "argv", ["", "--config", "./tests/conf/yaml/test_resolvers.yaml"])
+            os.environ['INT'] = "2"
+            os.environ['FLOAT'] = "2.0"
+            os.environ["BOOL"] = "true"
+            os.environ["STRING"] = "boo"
+            config = SpockBuilder(EnvClass)
+            return config.generate()
+
+    @staticmethod
+    @pytest.fixture
+    def crypto_builder_direct_api(monkeypatch):
+        with monkeypatch.context() as m:
+            m.setattr(sys, "argv", [""])
+            config = SpockBuilder(FromCrypto, salt='D7fqSVsaFJH2dbjT', key=b'hXYua9l1jbadIqTYdHtM_g7RKI3WwndMYlYuwNJsMpE=')
+            return config.generate()
+
+    @staticmethod
+    @pytest.fixture
+    def crypto_builder_env_api(monkeypatch):
+        with monkeypatch.context() as m:
+            m.setattr(sys, "argv", [""])
+            os.environ['SALT'] = "D7fqSVsaFJH2dbjT"
+            os.environ["KEY"] = "hXYua9l1jbadIqTYdHtM_g7RKI3WwndMYlYuwNJsMpE="
+            config = SpockBuilder(FromCrypto, salt='${spock.env:SALT}',
+                                  key='${spock.env:KEY}')
+            return config.generate()
+
+    @staticmethod
+    @pytest.fixture
+    def crypto_builder_yaml(monkeypatch):
+        with monkeypatch.context() as m:
+            m.setattr(sys, "argv", [""])
+            config = SpockBuilder(FromCrypto, salt='./tests/conf/yaml/test_salt.yaml',
+                                  key='./tests/conf/yaml/test_key.yaml')
+            return config.generate()
+
+    def test_crypto_from_direct_api(self, crypto_builder_direct_api):
+        assert crypto_builder_direct_api.FromCrypto.env_int_def_from_crypto == 100
+        assert crypto_builder_direct_api.FromCrypto.env_float_def_from_crypto == 100.0
+        assert crypto_builder_direct_api.FromCrypto.env_str_def_from_crypto == "hidden"
+        assert crypto_builder_direct_api.FromCrypto.env_bool_def_from_crypto is True
+
+    def test_crypto_from_env_api(self, crypto_builder_env_api):
+        assert crypto_builder_env_api.FromCrypto.env_int_def_from_crypto == 100
+        assert crypto_builder_env_api.FromCrypto.env_float_def_from_crypto == 100.0
+        assert crypto_builder_env_api.FromCrypto.env_str_def_from_crypto == "hidden"
+        assert crypto_builder_env_api.FromCrypto.env_bool_def_from_crypto is True
+
+    def test_crypto_from_yaml(self, crypto_builder_yaml):
+        assert crypto_builder_yaml.FromCrypto.env_int_def_from_crypto == 100
+        assert crypto_builder_yaml.FromCrypto.env_float_def_from_crypto == 100.0
+        assert crypto_builder_yaml.FromCrypto.env_str_def_from_crypto == "hidden"
+        assert crypto_builder_yaml.FromCrypto.env_bool_def_from_crypto is True
+
+    def test_resolver_basic_no_conf(self, arg_builder_no_conf):
+        # Basic types no defaults
+        assert arg_builder_no_conf.EnvClass.env_int == 1
+        assert arg_builder_no_conf.EnvClass.env_float == 1.0
+        assert arg_builder_no_conf.EnvClass.env_bool is True
+        assert arg_builder_no_conf.EnvClass.env_str == "ciao"
+        # Basic types w/ defaults
+        assert arg_builder_no_conf.EnvClass.env_int_def == 3
+        assert arg_builder_no_conf.EnvClass.env_float_def == 3.0
+        assert arg_builder_no_conf.EnvClass.env_bool_def is True
+        assert arg_builder_no_conf.EnvClass.env_str_def == "hello"
+        # Basic types w/ defaults -- test injection
+        assert arg_builder_no_conf.EnvClass.env_int_def_inject == 30
+        assert arg_builder_no_conf.EnvClass.env_float_def_inject == 30.0
+        assert arg_builder_no_conf.EnvClass.env_bool_def_inject is False
+        assert arg_builder_no_conf.EnvClass.env_str_def_inject == "hola"
+        # Basic types w/ defaults -- test crypto
+        assert arg_builder_no_conf.EnvClass.env_int_def_crypto == 300
+        assert arg_builder_no_conf.EnvClass.env_float_def_crypto == 300.0
+        assert arg_builder_no_conf.EnvClass.env_bool_def_crypto is True
+        assert arg_builder_no_conf.EnvClass.env_str_def_crypto == "yikes"
+        # Basic types optional -- None
+        assert arg_builder_no_conf.EnvClass.env_int_def_opt is None
+        assert arg_builder_no_conf.EnvClass.env_float_def_opt is None
+        assert arg_builder_no_conf.EnvClass.env_bool_def_opt is False
+        assert arg_builder_no_conf.EnvClass.env_str_def_opt is None
+
+    def test_resolver_basic_conf(self, arg_builder_conf):
+        # Basic types no defaults
+        assert arg_builder_conf.EnvClass.env_int == 2
+        assert arg_builder_conf.EnvClass.env_float == 2.0
+        assert arg_builder_conf.EnvClass.env_bool is True
+        assert arg_builder_conf.EnvClass.env_str == "boo"
+        # Basic types w/ defaults
+        assert arg_builder_conf.EnvClass.env_int_def == 4
+        assert arg_builder_conf.EnvClass.env_float_def == 4.0
+        assert arg_builder_conf.EnvClass.env_bool_def is False
+        assert arg_builder_conf.EnvClass.env_str_def == "rawr"
+        # Basic types optional -- None
+        assert arg_builder_conf.EnvClass.env_int_def_opt is None
+        assert arg_builder_conf.EnvClass.env_float_def_opt is None
+        assert arg_builder_conf.EnvClass.env_bool_def_opt is False
+        assert arg_builder_conf.EnvClass.env_str_def_opt is None

--- a/tests/base/test_state.py
+++ b/tests/base/test_state.py
@@ -46,4 +46,8 @@ class TestSerializedState:
                 *all_configs,
                 desc="Test Builder",
             ).generate()
+            delattr(config_values, '__key__')
+            delattr(config_values, '__salt__')
+            delattr(de_serial_config, '__key__')
+            delattr(de_serial_config, '__salt__')
             assert config_values == de_serial_config

--- a/tests/conf/yaml/test_incorrect.yaml
+++ b/tests/conf/yaml/test_incorrect.yaml
@@ -1,7 +1,7 @@
 # conf file for all YAML tests
 ### Required or Boolean Base Types ###
 # Boolean - Set
---bool_p_set
+bool_p_set: true
 failure: 10.0
 # Required Int
 int_p: 10

--- a/tests/conf/yaml/test_key.yaml
+++ b/tests/conf/yaml/test_key.yaml
@@ -1,0 +1,1 @@
+key: "hXYua9l1jbadIqTYdHtM_g7RKI3WwndMYlYuwNJsMpE="

--- a/tests/conf/yaml/test_resolvers.yaml
+++ b/tests/conf/yaml/test_resolvers.yaml
@@ -1,0 +1,15 @@
+EnvClass:
+  env_int: "${spock.env:INT}"
+  env_float: "${spock.env:FLOAT}"
+  env_bool: "${spock.env:BOOL}"
+  env_str: "${spock.env:STRING}"
+  # Basic types w/ defaults
+  env_int_def:  "${spock.env:INT_DEF, 4}"
+  env_float_def: "${spock.env:FLOAT_DEF, 4.0}"
+  env_bool_def: "${spock.env:BOOL_DEF, False}"
+  env_str_def: "${spock.env:STRING_DEF, rawr}"
+  # Basic types allowing None as default
+  env_int_def_opt: "${spock.env:INT_DEF, None}"
+  env_float_def_opt: "${spock.env:FLOAT_DEF, None}"
+  env_bool_def_opt: "${spock.env:BOOL_DEF, False}"
+  env_str_def_opt: "${spock.env:STRING_DEF, None}"

--- a/tests/conf/yaml/test_salt.yaml
+++ b/tests/conf/yaml/test_salt.yaml
@@ -1,0 +1,1 @@
+salt: "D7fqSVsaFJH2dbjT"

--- a/website/docs/advanced_features/Resolvers.md
+++ b/website/docs/advanced_features/Resolvers.md
@@ -1,0 +1,279 @@
+# Resolvers
+
+`spock` currently supports a single resolver notation `.env` with two annotations `.crypto` and `.inject`.
+
+### Environment Resolver
+
+`spock` supports resolving value definitions from environmental variables with the following syntax, 
+`${spock.env:name, default}`. This will read the value from the named env variable and fall back on the default if 
+specified. Currently, environmental variable resolution only supports simple types: `float`, `int`, `string`, and 
+`bool`. For example, let's define a bunch of parameters that will rely on the environment resolver:
+
+```python
+from spock import spock
+from spock import SpockBuilder
+
+from typing import Optional
+import os
+
+# Set some ENV variables here just as an example -- these can/should already be defined in your local/cluster env
+os.environ['INT_ENV'] = "2"
+os.environ['FLOAT_ENV'] = "2.0"
+os.environ["BOOL_ENV"] = "true"
+os.environ["STRING_ENV"] = "boo"
+
+
+@spock
+class EnvClass:
+    # Basic types no defaults
+    env_int: int = "${spock.env:INT_ENV}"
+    env_float: float = "${spock.env:FLOAT_ENV}"
+    env_bool: bool = "${spock.env:BOOL_ENV}"
+    env_str: str = "${spock.env:STRING_ENV}"
+    # Basic types w/ defaults
+    env_int_def: int = "${spock.env:INT_DEF, 3}"
+    env_float_def: float = "${spock.env:FLOAT_DEF, 3.0}"
+    env_bool_def: bool = "${spock.env:BOOL_DEF, True}"
+    env_str_def: str = "${spock.env:STRING_DEF, hello}"
+    # Basic types allowing None as default
+    env_int_def_opt: Optional[int] = "${spock.env:INT_DEF, None}"
+    env_float_def_opt: Optional[float] = "${spock.env:FLOAT_DEF, None}"
+    env_bool_def_opt: Optional[bool] = "${spock.env:BOOL_DEF, False}"
+    env_str_def_opt: Optional[str] = "${spock.env:STRING_DEF, None}"
+
+config = SpockBuilder(EnvClass).generate().save(user_specified_path='/tmp')
+```
+
+These demonstrate the three common paradigms: (1) read from an env variable and if not present throw an exception since
+no default is defined, (2) read from an env variable and if not present fallback on the given default value, (3) read
+from an optional env variable and fallback on None or False if not present (i.e. optional values). The returned 
+`Spockspace` would be:
+
+```shell
+EnvClass: !!python/object:spock.backend.config.EnvClass
+  env_bool: true
+  env_bool_def: true
+  env_bool_def_opt: false
+  env_float: 2.0
+  env_float_def: 3.0
+  env_float_def_opt: null
+  env_int: 2
+  env_int_def: 3
+  env_int_def_opt: null
+  env_str: boo
+  env_str_def: hello
+  env_str_def_opt: null
+```
+
+and the saved output YAML (from the `.save` call) would be:
+
+```yaml
+EnvClass:
+  env_bool: true
+  env_bool_def: true
+  env_bool_def_opt: false
+  env_float: 2.0
+  env_float_def: 3.0
+  env_int: 2
+  env_int_def: 3
+  env_str: boo
+  env_str_def: hello
+```
+
+### Inject Annotation
+
+In some cases you might want to save the configuration state with the same references to the env variables that you
+defined the parameters with instead of the resolved variables. This is available via the `.inject` annotation that 
+can be added to the `.env` notation. For instance, let's change a few of the definitions above to use the `.inject` 
+annotation:
+
+```python
+from spock import spock
+from spock import SpockBuilder
+
+from typing import Optional
+import os
+
+# Set some ENV variables here just as an example -- these can/should already be defined in your local/cluster env
+os.environ['INT_ENV'] = "2"
+os.environ['FLOAT_ENV'] = "2.0"
+os.environ["BOOL_ENV"] = "true"
+os.environ["STRING_ENV"] = "boo"
+
+
+@spock
+class EnvClass:
+    # Basic types no defaults
+    env_int: int = "${spock.env:INT_ENV}"
+    env_float: float = "${spock.env:FLOAT_ENV}"
+    env_bool: bool = "${spock.env:BOOL_ENV}"
+    env_str: str = "${spock.env:STRING_ENV}"
+    # Basic types w/ defaults    env_int_def: int = "${spock.env.inject:INT_DEF, 3}"
+    env_float_def: float = "${spock.env.inject:FLOAT_DEF, 3.0}"
+    env_bool_def: bool = "${spock.env.inject:BOOL_DEF, True}"
+    env_str_def: str = "${spock.env.inject:STRING_DEF, hello}"
+    # Basic types allowing None as default
+    env_int_def_opt: Optional[int] = "${spock.env:INT_DEF, None}"
+    env_float_def_opt: Optional[float] = "${spock.env:FLOAT_DEF, None}"
+    env_bool_def_opt: Optional[bool] = "${spock.env:BOOL_DEF, False}"
+    env_str_def_opt: Optional[str] = "${spock.env:STRING_DEF, None}"
+
+config = SpockBuilder(EnvClass).generate().save(user_specified_path='/tmp')
+```
+
+The returned `Spockspace` within Python would still be the same as above:
+
+```shell
+EnvClass: !!python/object:spock.backend.config.EnvClass
+  env_bool: true
+  env_bool_def: true
+  env_bool_def_opt: false
+  env_float: 2.0
+  env_float_def: 3.0
+  env_float_def_opt: null
+  env_int: 2
+  env_int_def: 3
+  env_int_def_opt: null
+  env_str: boo
+  env_str_def: hello
+  env_str_def_opt: null
+```
+
+However, the saved output YAML (from the `.save` call) would change to a version where the values of those annotated 
+with the `.inject` annotation will fall back to the env syntax:
+
+```yaml
+EnvClass:
+  env_bool: true
+  env_bool_def: ${spock.env.inject:BOOL_DEF, True}
+  env_bool_def_opt: false
+  env_float: 2.0
+  env_float_def: ${spock.env.inject:FLOAT_DEF, 3.0}
+  env_int: 2
+  env_int_def: ${spock.env.inject:INT_DEF, 3}
+  env_str: boo
+  env_str_def: ${spock.env.inject:STRING_DEF, hello}
+```
+
+### Cryptographic Annotation
+
+Sometimes environmental variables within a set of `spock` definitions and `Spockspace` output might contain sensitive 
+information (i.e. a lot of cloud infra use env variables that might contain passwords, internal DNS domains, etc.) that 
+shouldn't be stored in simple plaintext. The `.crypto` annotation provides a simple way to hide these sensitive 
+variables while still maintaining the written/loadable state of the spock config by 'encrypting' annotated values. 
+
+For example, let's define a parameter that will rely on the environment resolver but contains sensitive information 
+such that we don't want to store it in plaintext (so we add the `.crypto` annotation):
+
+```python
+from spock import spock
+from spock import SpockBuilder
+import os
+
+# Set some ENV variables here just as an example -- these can/should already be defined in your local/cluster env
+os.environ['PASSWORD'] = "youshouldntseeme!"
+
+
+@spock
+class SecretClass:
+    # Basic types w/ defaults    env_int_def: int = "${spock.env.inject:INT_DEF, 3}"
+    env_float_def: float = "${spock.env.inject:FLOAT_DEF, 3.0}"
+    env_bool_def: bool = "${spock.env.inject:BOOL_DEF, True}"
+    env_str_def: str = "${spock.env.inject:STRING_DEF, hello}"
+    # A value that needs to be 'encrypted'
+    env_password: str = "${spock.env.crypto:PASSWORD}"
+
+config = SpockBuilder(SecretClass).generate().save(user_specified_path='/tmp')
+```
+
+The returned `Spockspace` within Python would contain plaintext information for use within code:
+
+```shell
+SecretClass: !!python/object:spock.backend.config.SecretClass
+  env_bool_def: true
+  env_float_def: 3.0
+  env_password: youshouldntseeme!
+  env_str_def: hello
+```
+
+However, the saved output YAML (from the `.save` call) would change to a version where the values of those values 
+annotated with the `.crypto` annotation will be encrypted with a salt and key (via 
+[Cryptography](https://github.com/pyca/cryptography)):
+
+```yaml
+SecretClass:
+  env_bool_def: ${spock.env.inject:BOOL_DEF, True}
+  env_float_def: ${spock.env.inject:FLOAT_DEF, 3.0}
+  env_password: ${spock.crypto:gAAAAABig8FexSFATx1hdYZa_Knk8wfS2KSb8ylqFWTcfBsC_1nprKK4_G6EI9hMAJ7C39sxDWMMEGlKBfeYsb_NTTCTeaRmlxO3T37_AlAwCWfgG0cnzmyZaTctquKRNc6RnKL8VK2m}
+  env_str_def: ${spock.env.inject:STRING_DEF, hello}
+```
+
+Additionally, two extra files will be written to file: a YAML containing the salt (`*.spock.cfg.salt.yaml`) and another 
+YAML containing the key (`*.spock.cfg.key.yaml`). These files contain the salt and key that were used to encrypt values
+annotated with `.crypto`.
+
+In order to use the 'encrypted' versions of `spock` parameters (from a config file or as a given default within the
+code) the `salt` and `key` used to encrypt the value must be passed to the `SpockBuilder` as keyword args. For 
+instance, let's use the output from above (here we set the default value for instructional purposes, but this could 
+also be the value in a configuration file):
+
+```python
+from spock import spock
+from spock import SpockBuilder
+import os
+
+# Set some ENV variables here just as an example -- these can/should already be defined in your local/cluster env
+os.environ['PASSWORD'] = "youshouldntseeme!"
+
+
+@spock
+class SecretClass:
+    # Basic types w/ defaults    env_int_def: int = "${spock.env.inject:INT_DEF, 3}"
+    env_float_def: float = "${spock.env.inject:FLOAT_DEF, 3.0}"
+    env_bool_def: bool = "${spock.env.inject:BOOL_DEF, True}"
+    env_str_def: str = "${spock.env.inject:STRING_DEF, hello}"
+    # A value that needs to be 'encrypted' -- here we 
+    env_password: str = "${spock.crypto:gAAAAABig8FexSFATx1hdYZa_Knk8wfS2KSb8ylqFWTcfBsC_1nprKK4_G6EI9hMAJ7C39sxDWMMEGlKBfeYsb_NTTCTeaRmlxO3T37_AlAwCWfgG0cnzmyZaTctquKRNc6RnKL8VK2m}"
+
+config = SpockBuilder(
+    SecretClass,
+    key="/path/to/file/b4635a04-7fba-42f7-9257-04532a4715fd.spock.cfg.key.yaml",
+    salt="/path/to/file/b4635a04-7fba-42f7-9257-04532a4715fd.spock.cfg.salt.yaml"
+).generate()
+```
+
+Here we pass in the path to the YAML files that contain the `salt` and `key` to the `SpockBuilder` which allows the
+'encrypted' values to be 'decrypted' and used within code. The returned `Spockspace` would be exactly as before:
+
+```shell
+SecretClass: !!python/object:spock.backend.config.SecretClass
+  env_bool_def: true
+  env_float_def: 3.0
+  env_password: youshouldntseeme!
+  env_str_def: hello
+```
+
+The `salt` and `key` can also be directly specified from a `str` and `ByteString` accordingly:
+
+```python
+config = SpockBuilder(
+    SecretClass,
+    key=b'9DbRPjN4B_aRBZjfhIgDUnzYLQcmK2gGURhmIDtamSA=',
+    salt="NrnNndAEbXD2PT6n"
+).generate()
+```
+
+or the `salt` and `key` can be specified as environmental variables which will then be resolved by the environment 
+resolver:
+
+```python
+config = SpockBuilder(
+    SecretClass,
+    key='${spock.env:KEY}',
+    salt="${spock.env:SALT}"
+).generate()
+```
+
+
+
+

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -129,6 +129,11 @@ module.exports = {
                     label: 'Evolve',
                     id: 'advanced_features/Evolve'
                 },
+                {
+                    type: 'doc',
+                    label: 'Resolvers',
+                    id: 'advanced_features/Resolvers'
+                },
             ],
         },
         {


### PR DESCRIPTION
## What does this PR do?

This adds a resolver for environment variables thus allowing the definition of simple `spock` parameters with the following syntax: `${spock.env:value, default}` -- this will read the value from an env variable and fall back on the default if given. Currently supports only simple python types: float, int, string, bool (there are no future plans to support complex types as value and type resolution would require significant effort)

Additionally, this PR also implements the ability to annotate these resolvers. Currently implemented are `inject` and `crypto`.

#### Inject
This will 'inject' the original env variable definition back into the saved `spock` state when writing to file. For instance, if a parameter is defined as with the inject annotation (by adding `.inject` to the env annotation):

```python
class Example:
    one: Optional[int] = "${spock.env.inject:DUMMY}"
```

`DUMMY` will be read from the environment variable and set to its actual value within the `Spockspace`, however when written to file instead of the read value being written, the original syntax will be written instead (thus still referencing the env variable and not fixing the value):

```yaml
Example:
  one: ${spock.env.inject:DUMMY}
````

#### Crypto
Sometimes these env variables or other given variables within a `spock` config might be sensitive information (i.e. a lot of cloud infra uses env variables that might contain passwords, internal DNS domains, etc.). Therefore, the crypto annotation (by adding `.crypto` to a resolver) provides a simple way to hide these sensitive variables while still maintaining the written/loadable state of the `spock` config by using the `cryptography` package (via a salt and key) to 'encrypt' these sensitive values and prevent them from being stored in plaintext.

For instance, here you can add the `.crypto` annotation to the `spock.env` notation to indicate that this variable should be 'encrypted' when writing to file.

```python
@spock
class Example:
    two: Optional[str] = "${spock.env.crypto:DUMMY,Foo}"
```

Producing...

```yaml
Example:
  two: "${spock.crypto:gAAAAABiesGutuzXLyE-jICdI3gFANcWydM2MhK9-WmB73wi4daP38gu1jmlCv-FjiP54Mv9cqT5YQdMn4qFrRg32-wzeZmOYAAm5uKmBXHWx6pxa70BO8c=}"
```


This will also dump a `*.spock.cfg.salt.yaml` `*.spock.cfg.key.yaml` to file with the same UUID which can be used to 'decrypt' these values within python code.

The `SpockBuilder` class now takes `key` and `salt` arguments which can be paths to the salt and key yaml files, direct values of the key (ByteString) and salt (string), or env resolvers to the salt and key (e.g. '${spock.env:SALT}') which will automatically 'decrypt' the values when building the `Spockspace`

Partial implementation of discussion in #243.


Bonus addition, saving the `spock` config with the `extra_info` flag now dumps all the currently installed packages within a commented block at the end of the file.


## Checklist
  - [x] Did you adhere to [PEP-8](https://www.python.org/dev/peps/pep-0008/) standards?
  - [x] Did you run black and isort prior to submitting your PR? 
  - [x] Does your PR pass all existing unit tests?
  - [x] Did you add associated unit tests for any additional functionality?
  - [x] Did you provide documentation ([Google Docstring format](https://google.github.io/styleguide/pyguide.html)) whenever possible, even for simple functions or classes?