### PR TITLE
Update contributor guide to include language from the template

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,15 @@
 # Contributing
+
+Thank you for contributing to Spock! This guide will help you get started and know what to expect. All contributions and project spaces are subject to our [Code of Conduct](https://github.com/fidelity/.github/blob/main/CODE_OF_CONDUCT.md).
+
 We welcome all contributions from the community! Any contributions to `spock` should come through valid Pull/Merge 
 Requests in the public repository.
+
+Please open an issue **unless** you are making a significant security disclosure.
+
+## How to disclose security concerns responsibly
+
+Please follow the instructions in our [security policy](https://github.com/fidelity/.github/blob/main/SECURITY.md) (also visible in the Security tab on the project's repo).
 
 ## Contribution Guidelines
 1. Adhere to [PEP-8](https://www.python.org/dev/peps/pep-0008/) standards.
@@ -8,3 +17,10 @@ Requests in the public repository.
 3. Any changes to core functionality must pass all existing unit tests.
 4. Additional functionality should have associated unit tests.
 5. Provide documentation ([Google Docstring format](https://google.github.io/styleguide/pyguide.html)) whenever possible, even for simple functions or classes.
+6. Your contribution must be received under the project's open source license.
+7. You must have permission to make the contribution. We strongly recommend including a Signed-off-by line to indicate your adherence to the [Developer Certificate of Origin](https://developercertificate.org/).
+
+
+## Getting help
+
+If you have other questions about this project, please open an issue. To reach the Fidelity OSPO directly, please email [opensource@fmr.com](mailto:opensource@fmr.com).


### PR DESCRIPTION
Signed-off-by: Brian Warner <brian.warner2@fmr.com>

---
name: Update the contributor guide
about: Merges in language from the new standard template

---

## What does this PR do?
Fidelity is updating and standardizing our GitHub presence. This PR adds various guidelines from the default contributor guide.

## Checklist

N/A for this PR (governance related)

  - [ ] Did you adhere to [PEP-8](https://www.python.org/dev/peps/pep-0008/) standards?
  - [ ] Did you run black and isort prior to submitting your PR? 
  - [ ] Does your PR pass all existing unit tests?
  - [ ] Did you add associated unit tests for any additional functionality?
  - [ ] Did you provide code documentation ([Google Docstring format](https://google.github.io/styleguide/pyguide.html)) whenever possible, even for simple functions or classes?
  - [ ] Did you add necessary documentation to the website?

## Review
Request will go to reviewers to approve for merge.