### PR TITLE
Fix: Bug in Optional of GenericType

### DIFF
--- a/spock/backend/config.py
+++ b/spock/backend/config.py
@@ -38,6 +38,7 @@ def _base_attr(cls, kw_only, make_init, dynamic):
     bases = ()
     base_annotation = {}
     base_defaults = {}
+    base_optional = {}
     if len(cls.__mro__[1:-1]) > 0:
         # Get bases minus self and python class object
         bases = list(cls.__mro__[1:-1])
@@ -63,6 +64,10 @@ def _base_attr(cls, kw_only, make_init, dynamic):
                     else:
                         base_annotation.update(
                             {attribute.name: val.__annotations__[attribute.name]}
+                        )
+                    if "optional" in attribute.metadata:
+                        base_optional.update(
+                            {attribute.name: attribute.metadata["optional"]}
                         )
         base_defaults = {
             attribute.name: attribute.default
@@ -120,7 +125,13 @@ def _base_attr(cls, kw_only, make_init, dynamic):
             default = base_defaults[k]
         else:
             default = None
-        attrs_dict.update({k: katra(typed=v, default=default)})
+        # If the parent was optional then set the child to optional
+        optional = False
+        if k in base_optional:
+            optional = base_optional[k]
+        attrs_dict.update(
+            {k: katra(typed=v, default=default, inherit_optional=optional)}
+        )
     return bases, attrs_dict, merged_annotations
 
 

--- a/spock/backend/typed.py
+++ b/spock/backend/typed.py
@@ -561,16 +561,18 @@ def _callable_katra(typed, default=None, optional=False):
     return x
 
 
-def katra(typed, default=None):
+def katra(typed, default=None, inherit_optional=False):
     """Public interface to create a katra
 
-    A 'katra' is the basic functional unit of `spock`. It defines a parameter using attrs as the backend, type checks
-    both simple types and subscripted GenericAlias types (e.g. lists and tuples), handles setting default parameters,
+    A 'katra' is the basic functional unit of `spock`. It defines a parameter using
+    attrs as the backend, type checks both simple types and subscripted GenericAlias
+    types (e.g. lists and tuples), handles setting default parameters,
     and deals with parameter optionality
 
     Args:
         typed: the type of the parameter to define
         default: the default value to assign if given
+        inherit_optional: optionality from inheritance
 
     Returns:
         x: Attribute from attrs
@@ -578,6 +580,9 @@ def katra(typed, default=None):
     """
     # Handle optionals
     typed, optional = _handle_optional_typing(typed)
+    # Since we strip away the optional typing notation for Generics -- we need to
+    # override with optional coming from the parent
+    optional = True if (optional or inherit_optional) else False
     # Checks for callables via the different Variadic types across versions
     if isinstance(typed, _SpockVariadicGenericAlias):
         x = _callable_katra(typed=typed, default=default, optional=optional)

--- a/spock/builder.py
+++ b/spock/builder.py
@@ -24,6 +24,7 @@ from spock.backend.saver import AttrSaver
 from spock.backend.wrappers import Spockspace
 from spock.exceptions import _SpockCryptoError, _SpockEvolveError, _SpockValueError
 from spock.handlers import YAMLHandler
+from spock.helpers import to_dict
 from spock.utils import (
     _C,
     _T,
@@ -635,31 +636,12 @@ class ConfigArgBuilder:
         """Converts spock classes from a Spockspace into their dictionary representations
 
         Args:
-            objs: single spock class or an iterable of spock classes
+            obj: single spock class or an iterable of spock classes
 
         Returns:
             dictionary where the class names are keys and the values are the dictionary representations
         """
-
-        from spock.helpers import to_dict
-
         return to_dict(obj, self._saver_obj)
-
-        # if isinstance(obj, (List, Tuple)):
-        #     obj_dict = {}
-        #     for val in obj:
-        #         if not _is_spock_instance(val):
-        #             raise _SpockValueError(
-        #                 f"Object is not a @spock decorated class object -- currently `{type(val)}`"
-        #             )
-        #         obj_dict.update({type(val).__name__: val})
-        # elif _is_spock_instance(obj):
-        #     obj_dict = {type(obj).__name__: obj}
-        # else:
-        #     raise _SpockValueError(
-        #         f"Object is not a @spock decorated class object -- currently `{type(obj)}`"
-        #     )
-        # return self.spockspace_2_dict(Spockspace(**obj_dict))
 
     def evolve(self, *args: _C) -> Spockspace:
         """Function that allows a user to evolve the underlying spock classes with

--- a/tests/base/attr_configs_test.py
+++ b/tests/base/attr_configs_test.py
@@ -393,6 +393,11 @@ class TypeInherited(TypeConfig, TypeDefaultOptConfig):
     pass
 
 
+@spock
+class TypeOptionalInherited(TypeOptConfig):
+    pass
+
+
 class Foo:
     p: int = 1
 

--- a/tests/base/test_loaders.py
+++ b/tests/base/test_loaders.py
@@ -60,6 +60,7 @@ class TestInheritance(AllInherited):
             m.setattr(sys, "argv", ["", "--config", "./tests/conf/yaml/inherited.yaml"])
             config = ConfigArgBuilder(
                 TypeInherited,
+                TypeOptionalInherited,
                 NestedStuff,
                 NestedStuffOpt,
                 NestedListStuff,


### PR DESCRIPTION
## What does this PR do?
fixed bug in allowing inherited GenericType to be optional. since the typing.Optional annotation is stripped off of the parents we needed to pass on the optional metadata to override the typing check.

## Checklist
  - [x] Did you adhere to [PEP-8](https://www.python.org/dev/peps/pep-0008/) standards?
  - [x] Did you run black and isort prior to submitting your PR? 
  - [x] Does your PR pass all existing unit tests?
  - [x] Did you add associated unit tests for any additional functionality?
  - [x] Did you provide code documentation ([Google Docstring format](https://google.github.io/styleguide/pyguide.html)) whenever possible, even for simple functions or classes?
  - [x] Did you add necessary documentation to the website?

## Review
Request will go to reviewers to approve for merge.